### PR TITLE
Migrate object detection training to MediaPipe and add release automation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,6 +10,8 @@ labels
 downsampled
 data/
 dataset_release.json
+dataset.zip
+object-detection-dataset.zip
 exported_model/
 .mediapipe_cache/
 __pycache__/

--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,8 @@ local.properties
 images
 labels
 downsampled
+data/
+dataset_release.json
+exported_model/
+.mediapipe_cache/
+__pycache__/

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,21 @@
-FROM tensorflow/tensorflow:2.13.0-gpu
+FROM python:3.10-slim
+
+ENV PYTHONDONTWRITEBYTECODE=1 \
+    PYTHONUNBUFFERED=1
 
 RUN apt-get update && \
-    apt-get install -y libusb-1.0-0 libusb-1.0-0-dev
+    apt-get install -y --no-install-recommends \
+        build-essential \
+        libgl1 \
+        libglib2.0-0 \
+        libgomp1 \
+        libjpeg62-turbo \
+        libsm6 \
+        libxext6 \
+        libxrender1 && \
+    rm -rf /var/lib/apt/lists/*
 
-RUN pip install tflite-model-maker
-RUN pip install pycocotools
+RUN pip install --no-cache-dir --upgrade pip && \
+    pip install --no-cache-dir mediapipe-model-maker pycocotools
+
+WORKDIR /object-detection

--- a/Dockerfile
+++ b/Dockerfile
@@ -16,6 +16,9 @@ RUN apt-get update && \
     rm -rf /var/lib/apt/lists/*
 
 RUN pip install --no-cache-dir --upgrade pip && \
-    pip install --no-cache-dir mediapipe-model-maker pycocotools
+    pip install --no-cache-dir \
+        "tensorflow[and-cuda]==2.15.1" \
+        "mediapipe-model-maker==0.2.1.4" \
+        pycocotools
 
 WORKDIR /object-detection

--- a/README.md
+++ b/README.md
@@ -1,47 +1,171 @@
-This repo holds the python code for retraining the OIST smartphone robot object detector model.
-This model is used to detect other robots and charging pucks.  
+This repo holds the Python code used to retrain the OIST smartphone robot object detector model.
+The current training pipeline targets MediaPipe Model Maker and exports MediaPipe-compatible
+`.tflite` artifacts for the Android app.
 
-# Running model inference
-The model is used by an example Android app that can be found [here](https://github.com/oist/examples/tree/PuckMount/lite/examples/object_detection/android)
+The detector uses three classes:
 
-This is a fork of the [tf-model-maker](https://github.com/tensorflow/examples) repo that had a
-premade object detector app for Android using the tf-model-maker workflow. The app was modified
-to use the retrained model from this project along with the [abcvlib API](https://github.com/oist/smartphone-robot-android)
- to allow movement of the smartphone robots to the charging pucks.
+1. `puck`
+2. `robot-front`
+3. `robot-back`
 
-This project originally made use of [tf-model-maker](https://github.com/tensorflow/examples) but
-currently there are a LOT of existing issues. A clean install with latest dependencies does
- NOT work. So, this project will maintain a simple Dockerfile to hold the required working 
-dependencies to allow retraining until the tf-model-maker project starts working again, or 
-this project moves to the potential offshoot project called [Media Pipe](https://ai.google.dev/edge/mediapipe/solutions/model_maker)
+# Current Training Pipeline
+The legacy `tflite-model-maker` and `labelImg` flow has been replaced with:
 
-# Dependencies
-1. docker
-2. [Nvida container toolkit](https://docs.nvidia.com/datacenter/cloud-native/container-toolkit/latest/install-guide.html#id1)
+1. Images stored outside git as GitHub Release assets.
+2. Annotation with `X-AnyLabeling`.
+3. COCO export from `X-AnyLabeling`.
+4. Dataset preparation into train/validation/test splits.
+5. MediaPipe Model Maker retraining.
+6. Export of `.tflite` artifacts with metadata.
 
-# Retrain model
-`docker compose up --build`
-Note the default command is to run the retraining script (train.py).
-This takes all label data from ./labels, which is generated via labelImg (see below) 
-and retrains a efficientdet_lite0 model. The labels are currently xml files with the same name as the
-corresponding image help in ./images. These xml files contain relative paths to all image files, 
-bounding box, and label data. The exported model is saved as model.tflite in the root of the project.
+# Dataset Expectations
+The raw annotation export is expected to be a single COCO dataset zip with this layout:
 
-# Data Labeling
-The data labeling was done using [labelImg](https://github.com/HumanSignal/labelImg) but this project is no longer maintained
-and the follow up orject [Label Studio](https://github.com/HumanSignal/label-studio)
-did not provide a simple way to reuse the dataset created within labelImg. 
-The existing install instructions for labelImg did not work on Ubuntu >22.04, so a 
-docker container was created to run the labeling tool. The Dockerfile is hosted on a fork 
-of the original project [here](https://github.com/topherbuckley/labelImg)
+```text
+dataset-root/
+  images/
+    *.jpg
+    *.png
+  labels.json
+```
 
-The labeling will likely need to be updated to use a more modern tool, but for now the
-labelImg tool is sufficient for the small dataset used in this project.
+The COCO `categories` in `labels.json` must match:
 
-# Data Gathering
-The images used in this dataset were captured on a pixel 3a smartphone at higher resolution, but
-in order to speed up training were downsampled to 480 × 640 pixels. To batch downsample the images
-you can use the python script ./downsize.py. You will need to install Pillow via pip, 
-via `pip install Pillow`, but otherwise there shouldn't be any other dependencies.
-e.g. `python downsize.py ./images ./downsized`
-where `./images` hold raw images, and `./downsized` will hold the downsampled images.
+```text
+puck
+robot-front
+robot-back
+```
+
+The dataset zip should be published as a GitHub Release asset instead of being committed into git.
+
+# Starting From Local Images
+Right now the repo can start from your unlabeled local images in [images](/media/HDD/included/code/smartphone-robot/object-detection/images).
+
+The intended local-first flow is:
+
+1. Keep the raw images in `./images`.
+2. Open that image directory in `X-AnyLabeling`.
+3. Label every object using exactly these class names:
+   `puck`, `robot-front`, `robot-back`
+4. Export the finished annotations as a COCO dataset with:
+   `images/`
+   `labels.json`
+5. Validate the export locally.
+6. Package the validated COCO dataset into a release-ready zip.
+7. Optionally upload that zip as a GitHub Release asset.
+8. Prepare train/validation/test splits and train the model.
+
+# X-AnyLabeling Workflow
+Use `X-AnyLabeling` against the current local image directory and export a COCO dataset to a
+separate folder, for example:
+
+```text
+tmp/coco-export/
+  images/
+  labels.json
+```
+
+Important constraints:
+
+1. Use exactly these labels: `puck`, `robot-front`, `robot-back`
+2. Keep image filenames stable between annotation and export
+3. Ensure the export includes both the copied images and the COCO `labels.json`
+
+# Validate And Package A Finished COCO Export
+After you finish labeling in `X-AnyLabeling`, validate the local export:
+
+```bash
+python validate_coco.py /path/to/coco-export
+```
+
+If validation passes, package it into the release-ready zip format used by this repo:
+
+```bash
+python package_dataset.py /path/to/coco-export --output object-detection-dataset.zip
+```
+
+That zip can then be uploaded to a GitHub Release or used locally with:
+
+```bash
+python prepare_dataset.py --source-archive object-detection-dataset.zip
+```
+
+# Dataset Download And Preparation
+Create `dataset_release.json` from `dataset_release.example.json` and fill in the real GitHub
+Release tag, asset name, and optional SHA256 checksum.
+
+Then prepare the local MediaPipe dataset splits:
+
+```bash
+python prepare_dataset.py
+```
+
+This will:
+
+1. Download the configured release asset from `oist/smartphone_robot_object_detection`.
+2. Extract the COCO dataset into `data/raw/`.
+3. Split annotated images into `train`, `validation`, and `test` sets.
+4. Write MediaPipe-ready splits into `data/prepared/`.
+
+If the repository is private, set `GITHUB_TOKEN` before running the script.
+
+You can also bypass GitHub Releases and prepare from a local archive:
+
+```bash
+python prepare_dataset.py --source-archive /path/to/object-detection-dataset.zip
+```
+
+If you have not uploaded a release yet, this local archive path is the correct path to use.
+
+# Training
+The default training command assumes the prepared dataset layout created by `prepare_dataset.py`:
+
+```bash
+python train.py --export-fp16
+```
+
+Important paths:
+
+1. Training split: `data/prepared/train`
+2. Validation split: `data/prepared/validation`
+3. Optional test split: `data/prepared/test`
+4. Export directory: `exported_model/`
+
+The default model is `mobilenet_multi_avg_i384`, which is one of the currently supported
+MediaPipe object detector training architectures.
+
+Useful training flags:
+
+```bash
+python train.py --epochs 40 --batch-size 4
+python train.py --export-fp16
+python train.py --run-qat
+```
+
+`--export-fp16` exports `model_fp16.tflite` for GPU-oriented deployment.
+`--run-qat` adds quantization-aware training and exports `model_int8_qat.tflite` for CPU-oriented deployment.
+
+# Docker
+Build the training container and run the default training command:
+
+```bash
+docker compose up --build
+```
+
+The compose service now uses the MediaPipe training script directly. Prepare the dataset first so
+`data/prepared/` exists in the mounted workspace.
+
+# Android Integration
+This repo only covers model preparation and retraining. The Android app should consume the exported
+`.tflite` model through the MediaPipe object detector runtime.
+
+# Utilities
+`downsize.py` can still be used to downsample raw images before annotation or packaging:
+
+```bash
+python downsize.py ./images ./downsized
+```
+
+`downsize_xml.py` is retained only as a legacy helper for older Pascal VOC workflows and is no
+longer part of the supported training path.

--- a/README.md
+++ b/README.md
@@ -8,6 +8,11 @@ The detector uses three classes:
 2. `robot-front`
 3. `robot-back`
 
+The training pipeline now supports two label modes:
+
+1. `three-class` (default): `puck`, `robot-front`, `robot-back`
+2. `robot-merged`: `puck`, `robot`
+
 # Current Training Pipeline
 The legacy `tflite-model-maker` and `labelImg` flow has been replaced with:
 
@@ -36,6 +41,9 @@ puck
 robot-front
 robot-back
 ```
+
+`annotations/coco_detection.json` remains the source-of-truth 3-class export even when training a
+`robot-merged` variant. The merge happens during `prepare_dataset.py`.
 
 # Starting From Local Images
 The repo is designed to start from local images in [images](/media/HDD/included/code/smartphone-robot/object-detection/images).
@@ -98,7 +106,7 @@ Packaging is part of the intended workflow for this repo. Build the release-read
 directly from the local image folder and exported COCO annotations:
 
 ```bash
-python package_dataset.py --output object-detection-dataset.zip
+python package_dataset.py --output dataset.zip
 ```
 
 This creates a zip containing:
@@ -110,6 +118,8 @@ dataset-root/
 ```
 
 That archive is the expected GitHub Release asset format for later reuse.
+`dataset.zip` is the canonical asset name; `object-detection-dataset.zip` is still accepted as a
+legacy compatibility name when downloading older releases.
 
 # Training
 The default training command assumes the prepared dataset layout created by `prepare_dataset.py`:
@@ -134,10 +144,14 @@ Useful training flags:
 python train.py --epochs 40 --batch-size 4
 python train.py --export-fp16
 python train.py --run-qat
+python prepare_dataset.py --label-mode robot-merged
+python train.py --label-mode robot-merged --export-fp16
 ```
 
 `--export-fp16` exports `model_fp16.tflite` for GPU-oriented deployment.
 `--run-qat` adds quantization-aware training and exports `model_int8_qat.tflite` for CPU-oriented deployment.
+`--label-mode robot-merged` prepares and validates a 2-class variant that merges `robot-front` and
+`robot-back` into `robot`.
 
 # Docker
 Build the training container and run the default training command:
@@ -148,6 +162,43 @@ docker compose up --build
 
 The compose service now uses the MediaPipe training script directly. Prepare the dataset first so
 `data/prepared/` exists in the mounted workspace.
+
+# Release Publishing
+Versioned release assets are prepared under `build/release/<tag>/`. The release scripts rename the
+model artifacts so the shipped variant is obvious from the filename.
+
+Prepare release assets for the current 3-class model:
+
+```bash
+python scripts/prepare_release_assets.py --tag 2.0.0
+```
+
+Publish the GitHub release using those prepared assets:
+
+```bash
+python scripts/publish_release.py --tag 2.0.0
+```
+
+Release `2.0.0` is documented as the 3-class model release. The repository also supports
+`--label-mode robot-merged` for future training runs and future release variants.
+
+The scripts resolve release metadata in this order:
+
+1. `exported_model/training_summary.json` for metrics from fresh training runs
+2. `release_inputs/<tag>.json` for release-specific metadata and fallback metrics
+3. built-in defaults for the Docker image and title
+
+That keeps the common release flow short while still allowing older training runs to be published
+without editing the scripts.
+
+# DockerHub Publishing
+Build and publish the training image to DockerHub:
+
+```bash
+python scripts/publish_dockerhub.py --tag 2.0.0
+```
+
+The default DockerHub repository is `topher217/smartphone-robot-object-detection`.
 
 # Android Integration
 This repo only covers model preparation and retraining. The Android app should consume the exported

--- a/README.md
+++ b/README.md
@@ -11,25 +11,25 @@ The detector uses three classes:
 # Current Training Pipeline
 The legacy `tflite-model-maker` and `labelImg` flow has been replaced with:
 
-1. Images stored outside git as GitHub Release assets.
+1. Images in `./images`.
 2. Annotation with `X-AnyLabeling`.
-3. COCO export from `X-AnyLabeling`.
+3. COCO export to `./annotations/coco_detection.json`.
 4. Dataset preparation into train/validation/test splits.
 5. MediaPipe Model Maker retraining.
-6. Export of `.tflite` artifacts with metadata.
+6. Packaging the annotated dataset for GitHub Releases.
 
 # Dataset Expectations
-The raw annotation export is expected to be a single COCO dataset zip with this layout:
+The local source-of-truth dataset layout is:
 
 ```text
-dataset-root/
-  images/
-    *.jpg
-    *.png
-  labels.json
+images/
+  *.jpg
+  *.json      # X-AnyLabeling per-image files
+annotations/
+  coco_detection.json
 ```
 
-The COCO `categories` in `labels.json` must match:
+The COCO `categories` in `annotations/coco_detection.json` must match:
 
 ```text
 puck
@@ -37,10 +37,8 @@ robot-front
 robot-back
 ```
 
-The dataset zip should be published as a GitHub Release asset instead of being committed into git.
-
 # Starting From Local Images
-Right now the repo can start from your unlabeled local images in [images](/media/HDD/included/code/smartphone-robot/object-detection/images).
+The repo is designed to start from local images in [images](/media/HDD/included/code/smartphone-robot/object-detection/images).
 
 The intended local-first flow is:
 
@@ -48,54 +46,30 @@ The intended local-first flow is:
 2. Open that image directory in `X-AnyLabeling`.
 3. Label every object using exactly these class names:
    `puck`, `robot-front`, `robot-back`
-4. Export the finished annotations as a COCO dataset with:
-   `images/`
-   `labels.json`
-5. Validate the export locally.
-6. Package the validated COCO dataset into a release-ready zip.
-7. Optionally upload that zip as a GitHub Release asset.
-8. Prepare train/validation/test splits and train the model.
+4. Let `X-AnyLabeling` save its per-image JSON files in `./images`.
+5. Export COCO annotations to `./annotations/coco_detection.json`.
+6. Prepare train/validation/test splits and train the model.
+7. Package the annotated dataset into a release-ready zip.
+8. Upload that zip as a GitHub Release asset.
 
 # X-AnyLabeling Workflow
-Use `X-AnyLabeling` against the current local image directory and export a COCO dataset to a
-separate folder, for example:
-
-```text
-tmp/coco-export/
-  images/
-  labels.json
-```
+Use `X-AnyLabeling` against the current local image directory. Its default behavior of saving
+per-image JSON files alongside the images is fine. After labeling, export the combined COCO file to
+[annotations/coco_detection.json](/media/HDD/included/code/smartphone-robot/object-detection/annotations/coco_detection.json).
 
 Important constraints:
 
 1. Use exactly these labels: `puck`, `robot-front`, `robot-back`
 2. Keep image filenames stable between annotation and export
-3. Ensure the export includes both the copied images and the COCO `labels.json`
-
-# Validate And Package A Finished COCO Export
-After you finish labeling in `X-AnyLabeling`, validate the local export:
-
-```bash
-python validate_coco.py /path/to/coco-export
-```
-
-If validation passes, package it into the release-ready zip format used by this repo:
-
-```bash
-python package_dataset.py /path/to/coco-export --output object-detection-dataset.zip
-```
-
-That zip can then be uploaded to a GitHub Release or used locally with:
-
-```bash
-python prepare_dataset.py --source-archive object-detection-dataset.zip
-```
+3. Export the combined COCO file to `./annotations/coco_detection.json`
 
 # Dataset Download And Preparation
 Create `dataset_release.json` from `dataset_release.example.json` and fill in the real GitHub
 Release tag, asset name, and optional SHA256 checksum.
 
-Then prepare the local MediaPipe dataset splits:
+For local training, prepare the MediaPipe dataset splits directly from
+[images](/media/HDD/included/code/smartphone-robot/object-detection/images) and
+[annotations/coco_detection.json](/media/HDD/included/code/smartphone-robot/object-detection/annotations/coco_detection.json):
 
 ```bash
 python prepare_dataset.py
@@ -103,20 +77,39 @@ python prepare_dataset.py
 
 This will:
 
-1. Download the configured release asset from `oist/smartphone_robot_object_detection`.
-2. Extract the COCO dataset into `data/raw/`.
+1. Read the local images from `./images`.
+2. Read the COCO annotations from `./annotations/coco_detection.json`.
 3. Split annotated images into `train`, `validation`, and `test` sets.
 4. Write MediaPipe-ready splits into `data/prepared/`.
 
-If the repository is private, set `GITHUB_TOKEN` before running the script.
-
-You can also bypass GitHub Releases and prepare from a local archive:
+If you want to prepare from a packaged dataset archive instead, you can still use:
 
 ```bash
 python prepare_dataset.py --source-archive /path/to/object-detection-dataset.zip
 ```
 
-If you have not uploaded a release yet, this local archive path is the correct path to use.
+If neither the local images/annotations nor `--source-archive` are available, the script falls back
+to downloading the configured GitHub Release asset.
+
+If the repository is private, set `GITHUB_TOKEN` before using the release-download path.
+
+# Packaging For GitHub Releases
+Packaging is part of the intended workflow for this repo. Build the release-ready dataset archive
+directly from the local image folder and exported COCO annotations:
+
+```bash
+python package_dataset.py --output object-detection-dataset.zip
+```
+
+This creates a zip containing:
+
+```text
+dataset-root/
+  images/
+  labels.json
+```
+
+That archive is the expected GitHub Release asset format for later reuse.
 
 # Training
 The default training command assumes the prepared dataset layout created by `prepare_dataset.py`:
@@ -168,4 +161,5 @@ python downsize.py ./images ./downsized
 ```
 
 `downsize_xml.py` is retained only as a legacy helper for older Pascal VOC workflows and is no
-longer part of the supported training path.
+longer part of the supported training path. `validate_coco.py` remains available as an optional
+troubleshooting helper, but it is not required in the primary workflow.

--- a/classes.txt
+++ b/classes.txt
@@ -1,2 +1,2 @@
-p
-r
+puck
+robot

--- a/classes.txt
+++ b/classes.txt
@@ -1,2 +1,3 @@
 puck
-robot
+robot-front
+robot-back

--- a/dataset_release.example.json
+++ b/dataset_release.example.json
@@ -1,0 +1,6 @@
+{
+  "repo": "oist/smartphone_robot_object_detection",
+  "tag": "dataset-v1",
+  "asset": "object-detection-dataset.zip",
+  "sha256": ""
+}

--- a/dataset_release.example.json
+++ b/dataset_release.example.json
@@ -1,6 +1,6 @@
 {
   "repo": "oist/smartphone_robot_object_detection",
   "tag": "dataset-v1",
-  "asset": "object-detection-dataset.zip",
+  "asset": "dataset.zip",
   "sha256": ""
 }

--- a/dataset_release.example.json
+++ b/dataset_release.example.json
@@ -1,5 +1,5 @@
 {
-  "repo": "oist/smartphone_robot_object_detection",
+  "repo": "oist/smartphone-robot-object-detection",
   "tag": "dataset-v1",
   "asset": "dataset.zip",
   "sha256": ""

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -9,6 +9,7 @@ services:
     runtime: nvidia
     environment:
       - NVIDIA_VISIBLE_DEVICES=all
+      - NVIDIA_DRIVER_CAPABILITIES=compute,utility
     command: /bin/bash -c "cd /object-detection && python train.py"
     deploy:
       resources:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,20 +1,9 @@
 services:
-  tf-model-maker:
+  mediapipe-model-maker:
     build:
       context: .
       dockerfile: Dockerfile
-    image: tf-model-maker
+    image: mediapipe-model-maker
     volumes:
       - .:/object-detection
-    runtime: nvidia
-    environment:
-      - NVIDIA_VISIBLE_DEVICES=all
-      - NVIDIA_DRIVER_CAPABILITIES=compute,utility
-    command: /bin/bash -c "cd /object-detection && python train.py"
-    deploy:
-      resources:
-        reservations:
-          devices:
-            - driver: nvidia
-              count: 1
-              capabilities: [gpu]
+    command: python train.py --export-fp16

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -6,15 +6,8 @@ services:
     image: mediapipe-model-maker
     volumes:
       - .:/object-detection
-    runtime: nvidia
+    gpus: all
     environment:
       - NVIDIA_VISIBLE_DEVICES=all
       - NVIDIA_DRIVER_CAPABILITIES=compute,utility
     command: python train.py --export-fp16
-    deploy:
-      resources:
-        reservations:
-          devices:
-            - driver: nvidia
-              count: 1
-              capabilities: [gpu]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -6,4 +6,15 @@ services:
     image: mediapipe-model-maker
     volumes:
       - .:/object-detection
+    runtime: nvidia
+    environment:
+      - NVIDIA_VISIBLE_DEVICES=all
+      - NVIDIA_DRIVER_CAPABILITIES=compute,utility
     command: python train.py --export-fp16
+    deploy:
+      resources:
+        reservations:
+          devices:
+            - driver: nvidia
+              count: 1
+              capabilities: [gpu]

--- a/downsize_xml.py
+++ b/downsize_xml.py
@@ -1,0 +1,46 @@
+import os
+import xml.etree.ElementTree as ET
+
+# Define the directory containing the XML files
+directory = '.'
+
+# Define the scaling factors
+width_scale = 480 / 1944
+height_scale = 640 / 2592
+
+# Iterate over all files in the directory
+for filename in os.listdir(directory):
+    if filename.endswith('.xml'):
+        file_path = os.path.join(directory, filename)
+        
+        # Parse the XML file
+        tree = ET.parse(file_path)
+        root = tree.getroot()
+
+        # Update width and height
+        size = root.find('size')
+        if size is not None:
+            width = size.find('width')
+            height = size.find('height')
+            if width is not None and height is not None:
+                width.text = str(480)
+                height.text = str(640)
+
+        # Scale bounding boxes
+        for obj in root.findall('object'):
+            bndbox = obj.find('bndbox')
+            if bndbox is not None:
+                xmin = bndbox.find('xmin')
+                ymin = bndbox.find('ymin')
+                xmax = bndbox.find('xmax')
+                ymax = bndbox.find('ymax')
+                if xmin is not None and ymin is not None and xmax is not None and ymax is not None:
+                    xmin.text = str(round(int(xmin.text) * width_scale))
+                    ymin.text = str(round(int(ymin.text) * height_scale))
+                    xmax.text = str(round(int(xmax.text) * width_scale))
+                    ymax.text = str(round(int(ymax.text) * height_scale))
+
+        # Write the modified XML back to the file
+        tree.write(file_path)
+
+print("Processing completed.")

--- a/label_modes.py
+++ b/label_modes.py
@@ -1,0 +1,97 @@
+from __future__ import annotations
+
+from copy import deepcopy
+
+
+LABEL_MODE_THREE_CLASS = "three-class"
+LABEL_MODE_ROBOT_MERGED = "robot-merged"
+DEFAULT_LABEL_MODE = LABEL_MODE_THREE_CLASS
+LABEL_MODE_CHOICES = [LABEL_MODE_THREE_CLASS, LABEL_MODE_ROBOT_MERGED]
+
+THREE_CLASS_NAMES = ["puck", "robot-front", "robot-back"]
+ROBOT_MERGED_NAMES = ["puck", "robot"]
+
+_DISPLAY_NAMES = {
+    LABEL_MODE_THREE_CLASS: "3-class",
+    LABEL_MODE_ROBOT_MERGED: "robot-merged",
+}
+_FILE_SUFFIXES = {
+    LABEL_MODE_THREE_CLASS: "3class",
+    LABEL_MODE_ROBOT_MERGED: "robot-merged",
+}
+
+
+def expected_classes(label_mode: str) -> list[str]:
+    if label_mode == LABEL_MODE_THREE_CLASS:
+        return list(THREE_CLASS_NAMES)
+    if label_mode == LABEL_MODE_ROBOT_MERGED:
+        return list(ROBOT_MERGED_NAMES)
+    raise ValueError(f"Unsupported label mode: {label_mode}")
+
+
+def label_mode_display_name(label_mode: str) -> str:
+    if label_mode not in _DISPLAY_NAMES:
+        raise ValueError(f"Unsupported label mode: {label_mode}")
+    return _DISPLAY_NAMES[label_mode]
+
+
+def label_mode_file_suffix(label_mode: str) -> str:
+    if label_mode not in _FILE_SUFFIXES:
+        raise ValueError(f"Unsupported label mode: {label_mode}")
+    return _FILE_SUFFIXES[label_mode]
+
+
+def detect_label_mode(categories: list[str]) -> str:
+    if categories == THREE_CLASS_NAMES:
+        return LABEL_MODE_THREE_CLASS
+    if categories == ROBOT_MERGED_NAMES:
+        return LABEL_MODE_ROBOT_MERGED
+    raise ValueError(
+        f"Unsupported category set {categories}. Expected {THREE_CLASS_NAMES} or {ROBOT_MERGED_NAMES}."
+    )
+
+
+def _remap_category_name(name: str, label_mode: str) -> str:
+    if label_mode == LABEL_MODE_ROBOT_MERGED and name in {"robot-front", "robot-back", "robot"}:
+        return "robot"
+    return name
+
+
+def remap_coco_dataset(payload: dict, label_mode: str) -> dict:
+    remapped = deepcopy(payload)
+    source_categories = [
+        category["name"] for category in sorted(remapped["categories"], key=lambda item: item["id"])
+    ]
+    source_mode = detect_label_mode(source_categories)
+
+    if label_mode == source_mode:
+        return remapped
+    if label_mode != LABEL_MODE_ROBOT_MERGED:
+        raise ValueError(
+            f"Cannot derive label mode '{label_mode}' from source categories {source_categories}"
+        )
+
+    category_id_map: dict[int, int] = {}
+    name_to_new_id: dict[str, int] = {}
+    new_categories: list[dict] = []
+
+    for category in sorted(remapped["categories"], key=lambda item: item["id"]):
+        new_name = _remap_category_name(category["name"], label_mode)
+        if new_name not in name_to_new_id:
+            new_id = len(name_to_new_id) + 1
+            name_to_new_id[new_name] = new_id
+            new_category = dict(category)
+            new_category["id"] = new_id
+            new_category["name"] = new_name
+            new_categories.append(new_category)
+        category_id_map[category["id"]] = name_to_new_id[new_name]
+
+    remapped["categories"] = new_categories
+    remapped["annotations"] = [
+        {
+            **annotation,
+            "category_id": category_id_map[annotation["category_id"]],
+        }
+        for annotation in remapped["annotations"]
+    ]
+    return remapped

--- a/package_dataset.py
+++ b/package_dataset.py
@@ -1,7 +1,11 @@
 import argparse
+import json
 import shutil
 import zipfile
 from pathlib import Path
+
+DEFAULT_IMAGES_DIR = Path("images")
+DEFAULT_ANNOTATIONS = Path("annotations/coco_detection.json")
 
 
 def parse_args() -> argparse.Namespace:
@@ -9,8 +13,14 @@ def parse_args() -> argparse.Namespace:
         description="Package a local COCO dataset export into a release-ready zip archive.",
     )
     parser.add_argument(
-        "dataset_root",
-        help="Path to a COCO dataset directory containing images/ and labels.json.",
+        "--images-dir",
+        default=str(DEFAULT_IMAGES_DIR),
+        help="Path to the source image directory.",
+    )
+    parser.add_argument(
+        "--annotations",
+        default=str(DEFAULT_ANNOTATIONS),
+        help="Path to the COCO annotations JSON file.",
     )
     parser.add_argument(
         "--output",
@@ -34,14 +44,13 @@ def zip_directory(source_dir: Path, destination_zip: Path) -> None:
 
 def main() -> None:
     args = parse_args()
-    dataset_root = Path(args.dataset_root)
-    labels_path = dataset_root / "labels.json"
-    images_dir = dataset_root / "images"
+    images_dir = Path(args.images_dir)
+    labels_path = Path(args.annotations)
 
-    if not labels_path.is_file():
-        raise FileNotFoundError(f"Missing labels.json in {dataset_root}")
     if not images_dir.is_dir():
-        raise FileNotFoundError(f"Missing images directory in {dataset_root}")
+        raise FileNotFoundError(f"Missing images directory: {images_dir}")
+    if not labels_path.is_file():
+        raise FileNotFoundError(f"Missing COCO annotations file: {labels_path}")
 
     output_path = Path(args.output)
     staging_root = Path(args.staging_dir)
@@ -53,9 +62,15 @@ def main() -> None:
     (staging_dataset / "images").mkdir(parents=True, exist_ok=True)
     shutil.copy2(labels_path, staging_dataset / "labels.json")
 
-    for image_path in sorted(images_dir.iterdir()):
-        if image_path.is_file():
-            shutil.copy2(image_path, staging_dataset / "images" / image_path.name)
+    with labels_path.open("r", encoding="utf-8") as handle:
+        payload = json.load(handle)
+
+    referenced_filenames = sorted({image["file_name"] for image in payload.get("images", [])})
+    for filename in referenced_filenames:
+        image_path = images_dir / filename
+        if not image_path.is_file():
+            raise FileNotFoundError(f"Missing image referenced by COCO labels: {image_path}")
+        shutil.copy2(image_path, staging_dataset / "images" / image_path.name)
 
     output_path.parent.mkdir(parents=True, exist_ok=True)
     if output_path.exists():

--- a/package_dataset.py
+++ b/package_dataset.py
@@ -1,0 +1,70 @@
+import argparse
+import shutil
+import zipfile
+from pathlib import Path
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description="Package a local COCO dataset export into a release-ready zip archive.",
+    )
+    parser.add_argument(
+        "dataset_root",
+        help="Path to a COCO dataset directory containing images/ and labels.json.",
+    )
+    parser.add_argument(
+        "--output",
+        default="object-detection-dataset.zip",
+        help="Zip file path to create.",
+    )
+    parser.add_argument(
+        "--staging-dir",
+        default="data/package_staging",
+        help="Temporary staging directory used to normalize archive layout.",
+    )
+    return parser.parse_args()
+
+
+def zip_directory(source_dir: Path, destination_zip: Path) -> None:
+    with zipfile.ZipFile(destination_zip, "w", compression=zipfile.ZIP_DEFLATED) as archive:
+        for path in sorted(source_dir.rglob("*")):
+            if path.is_file():
+                archive.write(path, path.relative_to(source_dir))
+
+
+def main() -> None:
+    args = parse_args()
+    dataset_root = Path(args.dataset_root)
+    labels_path = dataset_root / "labels.json"
+    images_dir = dataset_root / "images"
+
+    if not labels_path.is_file():
+        raise FileNotFoundError(f"Missing labels.json in {dataset_root}")
+    if not images_dir.is_dir():
+        raise FileNotFoundError(f"Missing images directory in {dataset_root}")
+
+    output_path = Path(args.output)
+    staging_root = Path(args.staging_dir)
+    staging_dataset = staging_root / "dataset-root"
+
+    if staging_root.exists():
+        shutil.rmtree(staging_root)
+
+    (staging_dataset / "images").mkdir(parents=True, exist_ok=True)
+    shutil.copy2(labels_path, staging_dataset / "labels.json")
+
+    for image_path in sorted(images_dir.iterdir()):
+        if image_path.is_file():
+            shutil.copy2(image_path, staging_dataset / "images" / image_path.name)
+
+    output_path.parent.mkdir(parents=True, exist_ok=True)
+    if output_path.exists():
+        output_path.unlink()
+    zip_directory(staging_root, output_path)
+    shutil.rmtree(staging_root)
+
+    print(f"Packaged dataset archive: {output_path}")
+
+
+if __name__ == "__main__":
+    main()

--- a/package_dataset.py
+++ b/package_dataset.py
@@ -24,7 +24,7 @@ def parse_args() -> argparse.Namespace:
     )
     parser.add_argument(
         "--output",
-        default="object-detection-dataset.zip",
+        default="dataset.zip",
         help="Zip file path to create.",
     )
     parser.add_argument(

--- a/prepare_dataset.py
+++ b/prepare_dataset.py
@@ -17,7 +17,7 @@ from label_modes import (
     remap_coco_dataset,
 )
 
-DEFAULT_REPO = "oist/smartphone_robot_object_detection"
+DEFAULT_REPO = "oist/smartphone-robot-object-detection"
 DEFAULT_IMAGES_DIR = Path("images")
 DEFAULT_ANNOTATIONS = Path("annotations/coco_detection.json")
 DEFAULT_RELEASE_ASSET = "dataset.zip"

--- a/prepare_dataset.py
+++ b/prepare_dataset.py
@@ -9,11 +9,19 @@ import urllib.request
 import zipfile
 from pathlib import Path
 
+from label_modes import (
+    DEFAULT_LABEL_MODE,
+    LABEL_MODE_CHOICES,
+    detect_label_mode,
+    expected_classes,
+    remap_coco_dataset,
+)
 
-EXPECTED_CLASSES = ["puck", "robot-front", "robot-back"]
 DEFAULT_REPO = "oist/smartphone_robot_object_detection"
 DEFAULT_IMAGES_DIR = Path("images")
 DEFAULT_ANNOTATIONS = Path("annotations/coco_detection.json")
+DEFAULT_RELEASE_ASSET = "dataset.zip"
+LEGACY_RELEASE_ASSET = "object-detection-dataset.zip"
 
 
 def parse_args() -> argparse.Namespace:
@@ -54,6 +62,12 @@ def parse_args() -> argparse.Namespace:
         default="data/prepared",
         help="Directory containing the generated train/validation/test splits.",
     )
+    parser.add_argument(
+        "--label-mode",
+        choices=LABEL_MODE_CHOICES,
+        default=DEFAULT_LABEL_MODE,
+        help="Label variant to prepare. 'robot-merged' collapses robot-front and robot-back into robot.",
+    )
     parser.add_argument("--train-ratio", type=float, default=0.8)
     parser.add_argument("--validation-ratio", type=float, default=0.1)
     parser.add_argument("--test-ratio", type=float, default=0.1)
@@ -68,7 +82,7 @@ def load_manifest(manifest_path: Path) -> dict:
         )
     with manifest_path.open("r", encoding="utf-8") as handle:
         payload = json.load(handle)
-    for key in ("tag", "asset"):
+    for key in ("tag",):
         if key not in payload:
             raise ValueError(f"Manifest {manifest_path} is missing required key '{key}'")
     payload.setdefault("repo", DEFAULT_REPO)
@@ -94,13 +108,28 @@ def download_release_asset(manifest: dict, download_dir: Path) -> Path:
     with urllib.request.urlopen(github_request(release_url, "application/vnd.github+json")) as response:
         release_info = json.load(response)
 
+    configured_asset = manifest.get("asset")
+    asset_names = []
+    if configured_asset:
+        asset_names.append(configured_asset)
+        if configured_asset == DEFAULT_RELEASE_ASSET:
+            asset_names.append(LEGACY_RELEASE_ASSET)
+        elif configured_asset == LEGACY_RELEASE_ASSET:
+            asset_names.append(DEFAULT_RELEASE_ASSET)
+    else:
+        asset_names.extend([DEFAULT_RELEASE_ASSET, LEGACY_RELEASE_ASSET])
+
     asset = next(
-        (candidate for candidate in release_info.get("assets", []) if candidate["name"] == manifest["asset"]),
+        (
+            candidate
+            for candidate in release_info.get("assets", [])
+            if candidate["name"] in asset_names
+        ),
         None,
     )
     if asset is None:
         raise ValueError(
-            f"Could not find asset '{manifest['asset']}' on release tag '{manifest['tag']}'"
+            f"Could not find any dataset asset matching {asset_names} on release tag '{manifest['tag']}'"
         )
 
     destination = download_dir / asset["name"]
@@ -156,10 +185,7 @@ def load_coco_dataset_from_labels(labels_path: Path) -> dict:
     with labels_path.open("r", encoding="utf-8") as handle:
         payload = json.load(handle)
     categories = [category["name"] for category in sorted(payload["categories"], key=lambda item: item["id"])]
-    if categories != EXPECTED_CLASSES:
-        raise ValueError(
-            f"{labels_path} categories {categories} do not match expected {EXPECTED_CLASSES}"
-        )
+    detect_label_mode(categories)
     return payload
 
 
@@ -275,6 +301,16 @@ def main() -> None:
     annotated_images = [image for image in dataset["images"] if image["id"] in annotated_image_ids]
     if not annotated_images:
         raise ValueError("The COCO dataset contains no annotated images.")
+
+    dataset = remap_coco_dataset(dataset, args.label_mode)
+    prepared_categories = [
+        category["name"] for category in sorted(dataset["categories"], key=lambda item: item["id"])
+    ]
+    expected_category_names = expected_classes(args.label_mode)
+    if prepared_categories != expected_category_names:
+        raise ValueError(
+            f"Prepared categories {prepared_categories} do not match expected {expected_category_names}"
+        )
 
     split_map = split_images(
         annotated_images,

--- a/prepare_dataset.py
+++ b/prepare_dataset.py
@@ -12,6 +12,8 @@ from pathlib import Path
 
 EXPECTED_CLASSES = ["puck", "robot-front", "robot-back"]
 DEFAULT_REPO = "oist/smartphone_robot_object_detection"
+DEFAULT_IMAGES_DIR = Path("images")
+DEFAULT_ANNOTATIONS = Path("annotations/coco_detection.json")
 
 
 def parse_args() -> argparse.Namespace:
@@ -19,8 +21,18 @@ def parse_args() -> argparse.Namespace:
         description="Download and prepare a COCO dataset for MediaPipe object detector training.",
     )
     parser.add_argument(
+        "--images-dir",
+        default=str(DEFAULT_IMAGES_DIR),
+        help="Path to the local source image directory used with a local COCO export.",
+    )
+    parser.add_argument(
+        "--annotations",
+        default=str(DEFAULT_ANNOTATIONS),
+        help="Path to the local COCO annotations JSON export.",
+    )
+    parser.add_argument(
         "--source-archive",
-        help="Path to a local dataset zip. Skips GitHub download when set.",
+        help="Path to a local dataset zip. Used when preparing from a packaged dataset archive.",
     )
     parser.add_argument(
         "--release-manifest",
@@ -140,8 +152,7 @@ def find_coco_root(extract_root: Path) -> Path:
     return candidates[0]
 
 
-def load_coco_dataset(dataset_root: Path) -> dict:
-    labels_path = dataset_root / "labels.json"
+def load_coco_dataset_from_labels(labels_path: Path) -> dict:
     with labels_path.open("r", encoding="utf-8") as handle:
         payload = json.load(handle)
     categories = [category["name"] for category in sorted(payload["categories"], key=lambda item: item["id"])]
@@ -150,6 +161,19 @@ def load_coco_dataset(dataset_root: Path) -> dict:
             f"{labels_path} categories {categories} do not match expected {EXPECTED_CLASSES}"
         )
     return payload
+
+
+def load_local_coco_dataset(images_dir: Path, annotations_path: Path) -> tuple[dict, Path]:
+    if not images_dir.is_dir():
+        raise FileNotFoundError(f"Missing images directory: {images_dir}")
+    if not annotations_path.is_file():
+        raise FileNotFoundError(f"Missing COCO annotations file: {annotations_path}")
+    return load_coco_dataset_from_labels(annotations_path), images_dir
+
+
+def load_archive_coco_dataset(archive_path: Path, extract_dir: Path) -> tuple[dict, Path]:
+    dataset_root = extract_archive(archive_path, extract_dir)
+    return load_coco_dataset_from_labels(dataset_root / "labels.json"), dataset_root / "images"
 
 
 def split_images(images: list[dict], seed: int, train_ratio: float, validation_ratio: float) -> dict[str, list[dict]]:
@@ -198,7 +222,7 @@ def write_split(
     split_images_list: list[dict],
     annotations: list[dict],
     categories: list[dict],
-    source_root: Path,
+    source_images_dir: Path,
     prepared_dir: Path,
 ) -> None:
     split_dir = prepared_dir / split_name
@@ -211,7 +235,7 @@ def write_split(
     split_annotations = subset_annotations(annotations, image_ids)
 
     for image in split_images_list:
-        source_path = source_root / "images" / image["file_name"]
+        source_path = source_images_dir / image["file_name"]
         if not source_path.is_file():
             raise FileNotFoundError(f"Missing image referenced by COCO labels: {source_path}")
         copy_or_link(source_path, images_dir / image["file_name"])
@@ -232,17 +256,20 @@ def main() -> None:
     if abs(total_ratio - 1.0) > 1e-9:
         raise ValueError("train/validation/test ratios must sum to 1.0")
 
-    archive_path: Path
-    if args.source_archive:
+    local_images_dir = Path(args.images_dir)
+    local_annotations = Path(args.annotations)
+
+    if local_images_dir.is_dir() and local_annotations.is_file():
+        dataset, source_images_dir = load_local_coco_dataset(local_images_dir, local_annotations)
+    elif args.source_archive:
         archive_path = Path(args.source_archive)
         if not archive_path.is_file():
             raise FileNotFoundError(f"Dataset archive not found: {archive_path}")
+        dataset, source_images_dir = load_archive_coco_dataset(archive_path, Path(args.extract_dir))
     else:
         manifest = load_manifest(Path(args.release_manifest))
         archive_path = download_release_asset(manifest, Path(args.download_dir))
-
-    dataset_root = extract_archive(archive_path, Path(args.extract_dir))
-    dataset = load_coco_dataset(dataset_root)
+        dataset, source_images_dir = load_archive_coco_dataset(archive_path, Path(args.extract_dir))
 
     annotated_image_ids = {annotation["image_id"] for annotation in dataset["annotations"]}
     annotated_images = [image for image in dataset["images"] if image["id"] in annotated_image_ids]
@@ -264,7 +291,7 @@ def main() -> None:
             split_images_list=split_images_list,
             annotations=dataset["annotations"],
             categories=dataset["categories"],
-            source_root=dataset_root,
+            source_images_dir=source_images_dir,
             prepared_dir=prepared_dir,
         )
 

--- a/prepare_dataset.py
+++ b/prepare_dataset.py
@@ -1,0 +1,275 @@
+import argparse
+import hashlib
+import json
+import os
+import random
+import shutil
+import urllib.error
+import urllib.request
+import zipfile
+from pathlib import Path
+
+
+EXPECTED_CLASSES = ["puck", "robot-front", "robot-back"]
+DEFAULT_REPO = "oist/smartphone_robot_object_detection"
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description="Download and prepare a COCO dataset for MediaPipe object detector training.",
+    )
+    parser.add_argument(
+        "--source-archive",
+        help="Path to a local dataset zip. Skips GitHub download when set.",
+    )
+    parser.add_argument(
+        "--release-manifest",
+        default="dataset_release.json",
+        help="JSON manifest describing the GitHub release asset to download.",
+    )
+    parser.add_argument(
+        "--download-dir",
+        default="data/downloads",
+        help="Directory where downloaded release assets are stored.",
+    )
+    parser.add_argument(
+        "--extract-dir",
+        default="data/raw",
+        help="Directory where the downloaded archive is extracted.",
+    )
+    parser.add_argument(
+        "--prepared-dir",
+        default="data/prepared",
+        help="Directory containing the generated train/validation/test splits.",
+    )
+    parser.add_argument("--train-ratio", type=float, default=0.8)
+    parser.add_argument("--validation-ratio", type=float, default=0.1)
+    parser.add_argument("--test-ratio", type=float, default=0.1)
+    parser.add_argument("--seed", type=int, default=42)
+    return parser.parse_args()
+
+
+def load_manifest(manifest_path: Path) -> dict:
+    if not manifest_path.is_file():
+        raise FileNotFoundError(
+            f"Missing {manifest_path}. Create it from dataset_release.example.json or pass --source-archive."
+        )
+    with manifest_path.open("r", encoding="utf-8") as handle:
+        payload = json.load(handle)
+    for key in ("tag", "asset"):
+        if key not in payload:
+            raise ValueError(f"Manifest {manifest_path} is missing required key '{key}'")
+    payload.setdefault("repo", DEFAULT_REPO)
+    return payload
+
+
+def github_request(url: str, accept: str) -> urllib.request.Request:
+    headers = {
+        "Accept": accept,
+        "User-Agent": "smartphone-robot-object-detection/mediapipe-migration",
+    }
+    token = os.environ.get("GITHUB_TOKEN")
+    if token:
+        headers["Authorization"] = f"Bearer {token}"
+    return urllib.request.Request(url, headers=headers)
+
+
+def download_release_asset(manifest: dict, download_dir: Path) -> Path:
+    download_dir.mkdir(parents=True, exist_ok=True)
+    release_url = (
+        f"https://api.github.com/repos/{manifest['repo']}/releases/tags/{manifest['tag']}"
+    )
+    with urllib.request.urlopen(github_request(release_url, "application/vnd.github+json")) as response:
+        release_info = json.load(response)
+
+    asset = next(
+        (candidate for candidate in release_info.get("assets", []) if candidate["name"] == manifest["asset"]),
+        None,
+    )
+    if asset is None:
+        raise ValueError(
+            f"Could not find asset '{manifest['asset']}' on release tag '{manifest['tag']}'"
+        )
+
+    destination = download_dir / asset["name"]
+    with urllib.request.urlopen(github_request(asset["url"], "application/octet-stream")) as response:
+        with destination.open("wb") as handle:
+            shutil.copyfileobj(response, handle)
+
+    expected_sha256 = manifest.get("sha256")
+    if expected_sha256:
+        actual_sha256 = sha256_file(destination)
+        if actual_sha256 != expected_sha256:
+            raise ValueError(
+                f"Checksum mismatch for {destination}: expected {expected_sha256}, got {actual_sha256}"
+            )
+
+    return destination
+
+
+def sha256_file(path: Path) -> str:
+    digest = hashlib.sha256()
+    with path.open("rb") as handle:
+        for chunk in iter(lambda: handle.read(1024 * 1024), b""):
+            digest.update(chunk)
+    return digest.hexdigest()
+
+
+def extract_archive(archive_path: Path, extract_dir: Path) -> Path:
+    extract_dir.mkdir(parents=True, exist_ok=True)
+    dataset_root = extract_dir / archive_path.stem
+    if dataset_root.exists():
+        shutil.rmtree(dataset_root)
+    dataset_root.mkdir(parents=True, exist_ok=True)
+    with zipfile.ZipFile(archive_path, "r") as archive:
+        archive.extractall(dataset_root)
+    return find_coco_root(dataset_root)
+
+
+def find_coco_root(extract_root: Path) -> Path:
+    candidates = []
+    for candidate in [extract_root, *extract_root.rglob("*")]:
+        if not candidate.is_dir():
+            continue
+        if (candidate / "labels.json").is_file() and (candidate / "images").is_dir():
+            candidates.append(candidate)
+    if len(candidates) != 1:
+        raise ValueError(
+            f"Expected exactly one COCO dataset root under {extract_root}, found {len(candidates)}"
+        )
+    return candidates[0]
+
+
+def load_coco_dataset(dataset_root: Path) -> dict:
+    labels_path = dataset_root / "labels.json"
+    with labels_path.open("r", encoding="utf-8") as handle:
+        payload = json.load(handle)
+    categories = [category["name"] for category in sorted(payload["categories"], key=lambda item: item["id"])]
+    if categories != EXPECTED_CLASSES:
+        raise ValueError(
+            f"{labels_path} categories {categories} do not match expected {EXPECTED_CLASSES}"
+        )
+    return payload
+
+
+def split_images(images: list[dict], seed: int, train_ratio: float, validation_ratio: float) -> dict[str, list[dict]]:
+    shuffled = list(images)
+    random.Random(seed).shuffle(shuffled)
+    total = len(shuffled)
+    if total < 3:
+        raise ValueError("Need at least 3 annotated images to create train/validation/test splits.")
+
+    train_cutoff = int(total * train_ratio)
+    validation_cutoff = train_cutoff + int(total * validation_ratio)
+
+    train_images = shuffled[:train_cutoff]
+    validation_images = shuffled[train_cutoff:validation_cutoff]
+    test_images = shuffled[validation_cutoff:]
+
+    for split_name, split_images_list in {
+        "train": train_images,
+        "validation": validation_images,
+        "test": test_images,
+    }.items():
+        if not split_images_list:
+            raise ValueError(f"Split '{split_name}' is empty. Adjust the split ratios or dataset size.")
+
+    return {
+        "train": train_images,
+        "validation": validation_images,
+        "test": test_images,
+    }
+
+
+def subset_annotations(annotations: list[dict], image_ids: set[int]) -> list[dict]:
+    return [annotation for annotation in annotations if annotation["image_id"] in image_ids]
+
+
+def copy_or_link(source: Path, destination: Path) -> None:
+    destination.parent.mkdir(parents=True, exist_ok=True)
+    try:
+        os.link(source, destination)
+    except OSError:
+        shutil.copy2(source, destination)
+
+
+def write_split(
+    split_name: str,
+    split_images_list: list[dict],
+    annotations: list[dict],
+    categories: list[dict],
+    source_root: Path,
+    prepared_dir: Path,
+) -> None:
+    split_dir = prepared_dir / split_name
+    if split_dir.exists():
+        shutil.rmtree(split_dir)
+    images_dir = split_dir / "images"
+    images_dir.mkdir(parents=True, exist_ok=True)
+
+    image_ids = {image["id"] for image in split_images_list}
+    split_annotations = subset_annotations(annotations, image_ids)
+
+    for image in split_images_list:
+        source_path = source_root / "images" / image["file_name"]
+        if not source_path.is_file():
+            raise FileNotFoundError(f"Missing image referenced by COCO labels: {source_path}")
+        copy_or_link(source_path, images_dir / image["file_name"])
+
+    split_payload = {
+        "images": split_images_list,
+        "annotations": split_annotations,
+        "categories": categories,
+    }
+    with (split_dir / "labels.json").open("w", encoding="utf-8") as handle:
+        json.dump(split_payload, handle, indent=2)
+        handle.write("\n")
+
+
+def main() -> None:
+    args = parse_args()
+    total_ratio = args.train_ratio + args.validation_ratio + args.test_ratio
+    if abs(total_ratio - 1.0) > 1e-9:
+        raise ValueError("train/validation/test ratios must sum to 1.0")
+
+    archive_path: Path
+    if args.source_archive:
+        archive_path = Path(args.source_archive)
+        if not archive_path.is_file():
+            raise FileNotFoundError(f"Dataset archive not found: {archive_path}")
+    else:
+        manifest = load_manifest(Path(args.release_manifest))
+        archive_path = download_release_asset(manifest, Path(args.download_dir))
+
+    dataset_root = extract_archive(archive_path, Path(args.extract_dir))
+    dataset = load_coco_dataset(dataset_root)
+
+    annotated_image_ids = {annotation["image_id"] for annotation in dataset["annotations"]}
+    annotated_images = [image for image in dataset["images"] if image["id"] in annotated_image_ids]
+    if not annotated_images:
+        raise ValueError("The COCO dataset contains no annotated images.")
+
+    split_map = split_images(
+        annotated_images,
+        seed=args.seed,
+        train_ratio=args.train_ratio,
+        validation_ratio=args.validation_ratio,
+    )
+
+    prepared_dir = Path(args.prepared_dir)
+    prepared_dir.mkdir(parents=True, exist_ok=True)
+    for split_name, split_images_list in split_map.items():
+        write_split(
+            split_name=split_name,
+            split_images_list=split_images_list,
+            annotations=dataset["annotations"],
+            categories=dataset["categories"],
+            source_root=dataset_root,
+            prepared_dir=prepared_dir,
+        )
+
+    print(f"Prepared dataset written to {prepared_dir}")
+
+
+if __name__ == "__main__":
+    main()

--- a/release_inputs/2.0.0.json
+++ b/release_inputs/2.0.0.json
@@ -1,0 +1,11 @@
+{
+  "title": "Smartphone Robot Detector 2.0.0",
+  "label_mode": "three-class",
+  "docker_image": "topher217/smartphone-robot-object-detection",
+  "metrics": {
+    "validation_ap": 0.6145924,
+    "validation_ap50": 0.8829758,
+    "test_ap": 0.6466049,
+    "test_ap50": 0.8102135
+  }
+}

--- a/release_inputs/example.json
+++ b/release_inputs/example.json
@@ -1,0 +1,11 @@
+{
+  "title": "Smartphone Robot Detector 2.1.0",
+  "label_mode": "three-class",
+  "docker_image": "topher217/smartphone-robot-object-detection",
+  "metrics": {
+    "validation_ap": null,
+    "validation_ap50": null,
+    "test_ap": null,
+    "test_ap50": null
+  }
+}

--- a/scripts/prepare_release_assets.py
+++ b/scripts/prepare_release_assets.py
@@ -1,0 +1,291 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import shutil
+import subprocess
+import sys
+from pathlib import Path
+
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+if str(REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(REPO_ROOT))
+
+from label_modes import (  # noqa: E402
+    DEFAULT_LABEL_MODE,
+    LABEL_MODE_CHOICES,
+    expected_classes,
+    label_mode_display_name,
+)
+
+
+DEFAULT_DOCKER_IMAGE = "topher217/smartphone-robot-object-detection"
+DEFAULT_RELEASE_DIR = REPO_ROOT / "build" / "release"
+DEFAULT_MODEL_DIR = REPO_ROOT / "exported_model"
+DEFAULT_RELEASE_INPUTS_DIR = REPO_ROOT / "release_inputs"
+DEFAULT_DATASET_ARCHIVE_NAME = "dataset.zip"
+LEGACY_DATASET_ARCHIVE_NAME = "object-detection-dataset.zip"
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description="Prepare versioned GitHub release assets for the trained detector.",
+    )
+    parser.add_argument("--tag", required=True, help="Release tag, for example 2.0.0.")
+    parser.add_argument(
+        "--label-mode",
+        choices=LABEL_MODE_CHOICES,
+        default=None,
+        help="Override the model variant documented in the release assets.",
+    )
+    parser.add_argument(
+        "--model-dir",
+        default=str(DEFAULT_MODEL_DIR),
+        help="Directory containing model.tflite and optional related outputs.",
+    )
+    parser.add_argument(
+        "--release-dir",
+        default=str(DEFAULT_RELEASE_DIR),
+        help="Directory where prepared release assets are written.",
+    )
+    parser.add_argument(
+        "--dataset-archive",
+        help="Existing dataset archive to reuse. If omitted, dataset.zip is preferred and legacy names are accepted.",
+    )
+    parser.add_argument(
+        "--release-input",
+        help="Optional JSON file describing release title, label mode, docker image, and fallback metrics.",
+    )
+    parser.add_argument(
+        "--docker-image",
+        default=None,
+        help="Override the Docker image repository documented in release notes.",
+    )
+    return parser.parse_args()
+
+
+def sha256_file(path: Path) -> str:
+    digest = hashlib.sha256()
+    with path.open("rb") as handle:
+        for chunk in iter(lambda: handle.read(1024 * 1024), b""):
+            digest.update(chunk)
+    return digest.hexdigest()
+
+
+def ensure_dataset_archive(args: argparse.Namespace, release_dir: Path) -> Path:
+    candidates = []
+    if args.dataset_archive:
+        candidates.append(Path(args.dataset_archive))
+    else:
+        candidates.extend(
+            [
+                REPO_ROOT / DEFAULT_DATASET_ARCHIVE_NAME,
+                REPO_ROOT / LEGACY_DATASET_ARCHIVE_NAME,
+            ]
+        )
+
+    for candidate in candidates:
+        if candidate.is_file():
+            return candidate
+
+    dataset_output = release_dir / DEFAULT_DATASET_ARCHIVE_NAME
+    subprocess.run(
+        [
+            sys.executable,
+            str(REPO_ROOT / "package_dataset.py"),
+            "--output",
+            str(dataset_output),
+        ],
+        check=True,
+        cwd=REPO_ROOT,
+    )
+    return dataset_output
+
+
+def load_release_input(tag: str, configured_path: str | None) -> dict:
+    candidate_paths = []
+    if configured_path:
+        candidate_paths.append(Path(configured_path))
+    candidate_paths.append(DEFAULT_RELEASE_INPUTS_DIR / f"{tag}.json")
+
+    for candidate in candidate_paths:
+        if candidate.is_file():
+            with candidate.open("r", encoding="utf-8") as handle:
+                return json.load(handle)
+    return {}
+
+
+def metric_value(summary: dict | None, release_input: dict, key: str) -> float | None:
+    metrics_override = release_input.get("metrics", {})
+    if key in metrics_override and metrics_override[key] is not None:
+        return metrics_override[key]
+    if not summary:
+        return None
+    metrics = (
+        summary.get("validation_metrics", {})
+        if key.startswith("validation_")
+        else summary.get("test_metrics", {})
+    )
+    metric_key = {
+        "validation_ap": "AP",
+        "validation_ap50": "AP50",
+        "test_ap": "AP",
+        "test_ap50": "AP50",
+    }[key]
+    return metrics.get(metric_key)
+
+
+def copy_if_exists(source: Path, destination: Path) -> bool:
+    if not source.is_file():
+        return False
+    shutil.copy2(source, destination)
+    return True
+
+
+def build_release_notes(
+    *,
+    tag: str,
+    label_mode: str,
+    docker_image: str,
+    metrics: dict[str, float | None],
+    asset_names: list[str],
+) -> str:
+    classes = ", ".join(expected_classes(label_mode))
+    lines = [
+        f"# Smartphone Robot Detector {tag}",
+        "",
+        f"- Published model variant: `{label_mode_display_name(label_mode)}`",
+        f"- Classes in this release: `{classes}`",
+        f"- Docker image: `{docker_image}:{tag}` and `{docker_image}:latest`",
+        "",
+        "## Included assets",
+        "",
+    ]
+    lines.extend([f"- `{name}`" for name in asset_names])
+    lines.extend(["", "## Metrics", ""])
+
+    if metrics["validation_ap"] is not None:
+        lines.append(f"- Validation AP: `{metrics['validation_ap']:.4f}`")
+    if metrics["validation_ap50"] is not None:
+        lines.append(f"- Validation AP50: `{metrics['validation_ap50']:.4f}`")
+    if metrics["test_ap"] is not None:
+        lines.append(f"- Test AP: `{metrics['test_ap']:.4f}`")
+    if metrics["test_ap50"] is not None:
+        lines.append(f"- Test AP50: `{metrics['test_ap50']:.4f}`")
+    if all(value is None for value in metrics.values()):
+        lines.append("- Metrics were not provided to the release asset generator.")
+
+    lines.extend(
+        [
+            "",
+            "## Notes",
+            "",
+            f"- `dataset.zip` is the canonical training-data asset name for this release line.",
+            f"- The repository also supports `--label-mode robot-merged` for future training runs.",
+        ]
+    )
+    if label_mode == DEFAULT_LABEL_MODE:
+        lines.append(
+            "- This release publishes the current 3-class model. The merged-robot variant is supported in the tooling but is only shipped when explicitly trained and published."
+        )
+    return "\n".join(lines) + "\n"
+
+
+def main() -> None:
+    args = parse_args()
+    model_dir = Path(args.model_dir)
+    if not model_dir.is_dir():
+        raise FileNotFoundError(f"Model directory not found: {model_dir}")
+
+    model_path = model_dir / "model.tflite"
+    if not model_path.is_file():
+        raise FileNotFoundError(f"Missing model artifact: {model_path}")
+
+    release_input = load_release_input(args.tag, args.release_input)
+    label_mode = args.label_mode or release_input.get("label_mode") or DEFAULT_LABEL_MODE
+    docker_image = args.docker_image or release_input.get("docker_image") or DEFAULT_DOCKER_IMAGE
+
+    release_dir = Path(args.release_dir) / args.tag
+    if release_dir.exists():
+        shutil.rmtree(release_dir)
+    release_dir.mkdir(parents=True, exist_ok=True)
+
+    dataset_archive = ensure_dataset_archive(args, release_dir)
+    dataset_asset_name = DEFAULT_DATASET_ARCHIVE_NAME
+    dataset_asset_path = release_dir / dataset_asset_name
+    if dataset_archive.resolve() != dataset_asset_path.resolve():
+        shutil.copy2(dataset_archive, dataset_asset_path)
+
+    model_asset_base = f"smartphone-robot-detector-{args.tag}-{label_mode_display_name(label_mode)}"
+    copied_assets: list[Path] = []
+
+    model_asset_path = release_dir / f"{model_asset_base}.tflite"
+    shutil.copy2(model_path, model_asset_path)
+    copied_assets.append(model_asset_path)
+
+    fp16_path = model_dir / "model_fp16.tflite"
+    if copy_if_exists(fp16_path, release_dir / f"{model_asset_base}-fp16.tflite"):
+        copied_assets.append(release_dir / f"{model_asset_base}-fp16.tflite")
+
+    metadata_path = model_dir / "metadata.json"
+    if copy_if_exists(metadata_path, release_dir / f"{model_asset_base}.metadata.json"):
+        copied_assets.append(release_dir / f"{model_asset_base}.metadata.json")
+
+    training_summary = model_dir / "training_summary.json"
+    summary_payload = None
+    if training_summary.is_file():
+        with training_summary.open("r", encoding="utf-8") as handle:
+            summary_payload = json.load(handle)
+        summary_asset = release_dir / f"{model_asset_base}.training-summary.json"
+        shutil.copy2(training_summary, summary_asset)
+        copied_assets.append(summary_asset)
+
+    copied_assets.append(dataset_asset_path)
+
+    metrics = {
+        "validation_ap": metric_value(summary_payload, release_input, "validation_ap"),
+        "validation_ap50": metric_value(summary_payload, release_input, "validation_ap50"),
+        "test_ap": metric_value(summary_payload, release_input, "test_ap"),
+        "test_ap50": metric_value(summary_payload, release_input, "test_ap50"),
+    }
+
+    manifest_payload = {
+        "tag": args.tag,
+        "title": release_input.get("title") or f"Smartphone Robot Detector {args.tag}",
+        "label_mode": label_mode,
+        "label_mode_display_name": label_mode_display_name(label_mode),
+        "classes": expected_classes(label_mode),
+        "docker_image": docker_image,
+        "assets": [path.name for path in copied_assets],
+        "metrics": metrics,
+    }
+    manifest_path = release_dir / "release-metadata.json"
+    with manifest_path.open("w", encoding="utf-8") as handle:
+        json.dump(manifest_payload, handle, indent=2)
+        handle.write("\n")
+    copied_assets.append(manifest_path)
+
+    notes_path = release_dir / "release-notes.md"
+    notes_path.write_text(
+        build_release_notes(
+            tag=args.tag,
+            label_mode=label_mode,
+            docker_image=docker_image,
+            metrics=metrics,
+            asset_names=[path.name for path in copied_assets],
+        ),
+        encoding="utf-8",
+    )
+
+    checksums_path = release_dir / "sha256sums.txt"
+    checksum_lines = [f"{sha256_file(path)}  {path.name}" for path in sorted(copied_assets, key=lambda item: item.name)]
+    checksums_path.write_text("\n".join(checksum_lines) + "\n", encoding="utf-8")
+
+    print(f"Prepared release assets in {release_dir}")
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/publish_dockerhub.py
+++ b/scripts/publish_dockerhub.py
@@ -1,0 +1,50 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import argparse
+import subprocess
+from pathlib import Path
+
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+DEFAULT_IMAGE = "topher217/smartphone-robot-object-detection"
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description="Build and push the training container image to DockerHub.",
+    )
+    parser.add_argument("--tag", required=True, help="Version tag to publish, for example 2.0.0.")
+    parser.add_argument("--image", default=DEFAULT_IMAGE, help="Docker image repository to publish.")
+    parser.add_argument(
+        "--skip-latest",
+        action="store_true",
+        help="Only publish the explicit version tag and skip the latest tag.",
+    )
+    return parser.parse_args()
+
+
+def run(command: list[str]) -> None:
+    subprocess.run(command, cwd=REPO_ROOT, check=True)
+
+
+def main() -> None:
+    args = parse_args()
+    tags = [f"{args.image}:{args.tag}"]
+    if not args.skip_latest:
+        tags.append(f"{args.image}:latest")
+
+    build_command = ["docker", "build", "-f", "Dockerfile"]
+    for tag in tags:
+        build_command.extend(["-t", tag])
+    build_command.append(".")
+    run(build_command)
+
+    for tag in tags:
+        run(["docker", "push", tag])
+
+    print(f"Published Docker image tags: {', '.join(tags)}")
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/publish_github_release.py
+++ b/scripts/publish_github_release.py
@@ -9,7 +9,7 @@ from pathlib import Path
 
 REPO_ROOT = Path(__file__).resolve().parents[1]
 DEFAULT_RELEASE_DIR = REPO_ROOT / "build" / "release"
-DEFAULT_REPO = "oist/smartphone_robot_object_detection"
+DEFAULT_REPO = "oist/smartphone-robot-object-detection"
 
 
 def parse_args() -> argparse.Namespace:

--- a/scripts/publish_github_release.py
+++ b/scripts/publish_github_release.py
@@ -1,0 +1,134 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import argparse
+import subprocess
+import sys
+from pathlib import Path
+
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+DEFAULT_RELEASE_DIR = REPO_ROOT / "build" / "release"
+DEFAULT_REPO = "oist/smartphone_robot_object_detection"
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description="Create or update a GitHub release from prepared detector assets.",
+    )
+    parser.add_argument("--tag", required=True, help="Release tag, for example 2.0.0.")
+    parser.add_argument("--title", help="Release title. Defaults to 'Smartphone Robot Detector <tag>'.")
+    parser.add_argument("--repo", default=DEFAULT_REPO, help="GitHub repository in owner/name form.")
+    parser.add_argument("--target", default="HEAD", help="Target commitish used when creating a new release.")
+    parser.add_argument("--release-dir", default=str(DEFAULT_RELEASE_DIR))
+    parser.add_argument("--dataset-archive")
+    parser.add_argument("--release-input")
+    parser.add_argument(
+        "--skip-prepare",
+        action="store_true",
+        help="Assume release assets already exist under build/release/<tag>.",
+    )
+    return parser.parse_args()
+
+
+def run_command(command: list[str]) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(
+        command,
+        cwd=REPO_ROOT,
+        check=False,
+        text=True,
+        capture_output=True,
+    )
+
+
+def maybe_prepare_assets(args: argparse.Namespace) -> None:
+    if args.skip_prepare:
+        return
+
+    command = [
+        sys.executable,
+        str(REPO_ROOT / "scripts" / "prepare_release_assets.py"),
+        "--tag",
+        args.tag,
+        "--release-dir",
+        args.release_dir,
+    ]
+    if args.dataset_archive:
+        command.extend(["--dataset-archive", args.dataset_archive])
+    if args.release_input:
+        command.extend(["--release-input", args.release_input])
+
+    subprocess.run(command, cwd=REPO_ROOT, check=True)
+
+
+def main() -> None:
+    args = parse_args()
+    maybe_prepare_assets(args)
+
+    release_dir = Path(args.release_dir) / args.tag
+    notes_path = release_dir / "release-notes.md"
+    if not notes_path.is_file():
+        raise FileNotFoundError(f"Missing release notes: {notes_path}")
+
+    assets = sorted(
+        path
+        for path in release_dir.iterdir()
+        if path.is_file() and path.name != "release-notes.md"
+    )
+    if not assets:
+        raise ValueError(f"No release assets found in {release_dir}")
+
+    metadata_path = release_dir / "release-metadata.json"
+    release_title = f"Smartphone Robot Detector {args.tag}"
+    if metadata_path.is_file():
+        import json
+
+        with metadata_path.open("r", encoding="utf-8") as handle:
+            release_title = json.load(handle).get("title", release_title)
+
+    title = args.title or release_title
+    view = run_command(["gh", "release", "view", args.tag, "--repo", args.repo])
+    if view.returncode == 0:
+        upload_command = ["gh", "release", "upload", args.tag, "--repo", args.repo, "--clobber"]
+        upload_command.extend(str(path) for path in assets)
+        subprocess.run(upload_command, cwd=REPO_ROOT, check=True)
+        subprocess.run(
+            [
+                "gh",
+                "release",
+                "edit",
+                args.tag,
+                "--repo",
+                args.repo,
+                "--title",
+                title,
+                "--notes-file",
+                str(notes_path),
+            ],
+            cwd=REPO_ROOT,
+            check=True,
+        )
+        print(f"Updated GitHub release {args.tag}")
+        return
+
+    create_command = [
+        "gh",
+        "release",
+        "create",
+        args.tag,
+        "--repo",
+        args.repo,
+        "--target",
+        args.target,
+        "--title",
+        title,
+        "--notes-file",
+        str(notes_path),
+    ]
+    create_command.extend(str(path) for path in assets)
+    subprocess.run(create_command, cwd=REPO_ROOT, check=True)
+    print(f"Created GitHub release {args.tag}")
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/publish_release.py
+++ b/scripts/publish_release.py
@@ -16,7 +16,7 @@ def parse_args() -> argparse.Namespace:
     )
     parser.add_argument("--tag", required=True, help="Release tag, for example 2.0.0.")
     parser.add_argument("--target", default="HEAD", help="Target commitish used when creating a new release.")
-    parser.add_argument("--repo", default="oist/smartphone_robot_object_detection")
+    parser.add_argument("--repo", default="oist/smartphone-robot-object-detection")
     parser.add_argument("--dataset-archive")
     parser.add_argument("--release-input")
     parser.add_argument("--title")

--- a/scripts/publish_release.py
+++ b/scripts/publish_release.py
@@ -1,0 +1,49 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import argparse
+import subprocess
+import sys
+from pathlib import Path
+
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description="Prepare and publish a GitHub release for the trained detector.",
+    )
+    parser.add_argument("--tag", required=True, help="Release tag, for example 2.0.0.")
+    parser.add_argument("--target", default="HEAD", help="Target commitish used when creating a new release.")
+    parser.add_argument("--repo", default="oist/smartphone_robot_object_detection")
+    parser.add_argument("--dataset-archive")
+    parser.add_argument("--release-input")
+    parser.add_argument("--title")
+    return parser.parse_args()
+
+
+def main() -> None:
+    args = parse_args()
+    command = [
+        sys.executable,
+        str(REPO_ROOT / "scripts" / "publish_github_release.py"),
+        "--tag",
+        args.tag,
+        "--target",
+        args.target,
+        "--repo",
+        args.repo,
+    ]
+    if args.dataset_archive:
+        command.extend(["--dataset-archive", args.dataset_archive])
+    if args.release_input:
+        command.extend(["--release-input", args.release_input])
+    if args.title:
+        command.extend(["--title", args.title])
+
+    subprocess.run(command, cwd=REPO_ROOT, check=True)
+
+
+if __name__ == "__main__":
+    main()

--- a/train.py
+++ b/train.py
@@ -15,6 +15,17 @@ logging.set_verbosity(logging.ERROR)
 
 labelDict = {'puck':'puck','robot':'robot'}
 
+gpus = tf.config.experimental.list_physical_devices('GPU')
+if gpus:
+    try:
+        tf.config.experimental.set_virtual_device_configuration(
+            gpus[0],
+            [tf.config.experimental.VirtualDeviceConfiguration(memory_limit=4096)])  # 4 GB limit
+    except RuntimeError as e:
+        print(e)
+
+print("Num GPUs Available: ", len(gpus))
+
 def xml_to_csv(path):
     xml_list = []
     globlist = glob.glob(path + '/*.xml')
@@ -86,7 +97,7 @@ train_data, validation_data, test_data = object_detector.DataLoader.from_csv('./
 
 print("loaded data set...creating model")
 
-model = object_detector.create(train_data, model_spec=spec, epochs=1, batch_size=64, train_whole_model=True, validation_data=validation_data)
+model = object_detector.create(train_data, model_spec=spec, epochs=100, batch_size=16, train_whole_model=True, validation_data=validation_data)
 print("created model.")
 
 # model.evaluate(test_data)

--- a/train.py
+++ b/train.py
@@ -1,113 +1,192 @@
-import glob
-import os
-import xml.etree.ElementTree as ET
+import argparse
+import json
+from pathlib import Path
 
-import pandas as pd
-import tensorflow as tf
-from tflite_model_maker import model_spec
-from tflite_model_maker import object_detector
+from mediapipe_model_maker import object_detector
+from mediapipe_model_maker import quantization
 
-assert tf.__version__.startswith('2')
 
-tf.get_logger().setLevel('ERROR')
-from absl import logging
-logging.set_verbosity(logging.ERROR)
+EXPECTED_CLASSES = ["puck", "robot-front", "robot-back"]
+SUPPORTED_MODELS = {
+    "mobilenet_v2": object_detector.SupportedModels.MOBILENET_V2,
+    "mobilenet_v2_i320": object_detector.SupportedModels.MOBILENET_V2_I320,
+    "mobilenet_multi_avg": object_detector.SupportedModels.MOBILENET_MULTI_AVG,
+    "mobilenet_multi_avg_i384": object_detector.SupportedModels.MOBILENET_MULTI_AVG_I384,
+}
 
-labelDict = {'puck':'puck','robot':'robot'}
 
-gpus = tf.config.experimental.list_physical_devices('GPU')
-if gpus:
-    try:
-        tf.config.experimental.set_virtual_device_configuration(
-            gpus[0],
-            [tf.config.experimental.VirtualDeviceConfiguration(memory_limit=4096)])  # 4 GB limit
-    except RuntimeError as e:
-        print(e)
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description="Train the smartphone robot detector with MediaPipe Model Maker.",
+    )
+    parser.add_argument(
+        "--train-data",
+        default="data/prepared/train",
+        help="Path to the COCO training split directory.",
+    )
+    parser.add_argument(
+        "--validation-data",
+        default="data/prepared/validation",
+        help="Path to the COCO validation split directory.",
+    )
+    parser.add_argument(
+        "--test-data",
+        default="data/prepared/test",
+        help="Optional path to the COCO test split directory.",
+    )
+    parser.add_argument(
+        "--output-dir",
+        default="exported_model",
+        help="Directory for exported model artifacts.",
+    )
+    parser.add_argument(
+        "--cache-dir",
+        default=".mediapipe_cache",
+        help="Directory used by MediaPipe for dataset caching.",
+    )
+    parser.add_argument(
+        "--model",
+        choices=sorted(SUPPORTED_MODELS),
+        default="mobilenet_multi_avg_i384",
+        help="MediaPipe supported model architecture.",
+    )
+    parser.add_argument("--epochs", type=int, default=30)
+    parser.add_argument("--batch-size", type=int, default=8)
+    parser.add_argument("--learning-rate", type=float, default=0.3)
+    parser.add_argument("--cosine-decay-epochs", type=int, default=None)
+    parser.add_argument("--cosine-decay-alpha", type=float, default=1.0)
+    parser.add_argument("--l2-weight-decay", type=float, default=3e-5)
+    parser.add_argument(
+        "--export-fp16",
+        action="store_true",
+        help="Also export a float16 quantized TFLite model for GPU-oriented use.",
+    )
+    parser.add_argument(
+        "--run-qat",
+        action="store_true",
+        help="Run quantization-aware training and export an int8 TFLite model.",
+    )
+    parser.add_argument("--qat-epochs", type=int, default=15)
+    parser.add_argument("--qat-batch-size", type=int, default=8)
+    parser.add_argument("--qat-learning-rate", type=float, default=0.3)
+    parser.add_argument("--qat-decay-steps", type=int, default=8)
+    parser.add_argument("--qat-decay-rate", type=float, default=0.96)
+    return parser.parse_args()
 
-print("Num GPUs Available: ", len(gpus))
 
-def xml_to_csv(path):
-    xml_list = []
-    globlist = glob.glob(path + '/*.xml')
-    totalBoundingBoxes = 0
-    idx = 0
-    for xml_file in globlist:
-        tree = ET.parse(xml_file)
-        root = tree.getroot()
-        boundingBoxes = root.findall('object')
-        totalBoundingBoxes += len(boundingBoxes)
-    for xml_file in globlist:
-        tree = ET.parse(xml_file)
-        root = tree.getroot()
-        boundingBoxes = root.findall('object')
+def load_categories(labels_path: Path) -> list[str]:
+    with labels_path.open("r", encoding="utf-8") as handle:
+        payload = json.load(handle)
+    categories = payload.get("categories", [])
+    return [category["name"] for category in sorted(categories, key=lambda item: item["id"])]
 
-        if (len(boundingBoxes) == 0):
-            # value = ("TRAINING",
-            #          'images/' + root.find('filename').text,
-            #          None,
-            #          None,
-            #          None,
-            #          None,
-            #          None,
-            #          None,
-            #          None,
-            #          None,
-            #          None,
-            #          )
-            # xml_list.append(value)
-            pass
-        else:
-            for member in boundingBoxes:
-                if idx > int(0.3 * totalBoundingBoxes):
-                    set = "TRAINING"
-                elif idx > int(0.1 * totalBoundingBoxes):
-                    set = "VALIDATION"
-                else:
-                    set = "TEST"
 
-                value = (set,
-                    # 'gs://dataset_pucks/images/' + root.find('filename').text,
-                    './images/' + root.find('filename').text,
-                    labelDict.get(member[0].text),
-                    int(member[4][0].text) / 480,
-                    int(member[4][1].text) / 640,
-                    None,
-                    None,
-                    int(member[4][2].text) / 480,
-                    int(member[4][3].text) / 640,
-                    None,
-                    None,
-                    )
-                xml_list.append(value)
-                idx += 1
+def validate_coco_split(split_dir: Path) -> None:
+    if not split_dir.exists():
+        raise FileNotFoundError(f"COCO split not found: {split_dir}")
 
-    column_name = ['set', 'filename', 'class', 'xmin', 'ymin', None, None, 'xmax', 'ymax', None, None]
-    xml_df = pd.DataFrame(xml_list, columns=column_name)
-    return xml_df
+    labels_path = split_dir / "labels.json"
+    images_dir = split_dir / "images"
+    if not labels_path.is_file():
+        raise FileNotFoundError(f"Missing labels.json in {split_dir}")
+    if not images_dir.is_dir():
+        raise FileNotFoundError(f"Missing images directory in {split_dir}")
 
-spec = model_spec.get('efficientdet_lite0')
+    categories = load_categories(labels_path)
+    if categories != EXPECTED_CLASSES:
+        raise ValueError(
+            f"{labels_path} categories {categories} do not match expected {EXPECTED_CLASSES}"
+        )
 
-print("started loading data set")
 
-image_path = os.path.join(os.getcwd(), 'labels')
-xml_df = xml_to_csv(image_path)
-xml_df.to_csv('images.csv', index=None, header=False)
-print('Successfully converted xml to csv.')
-train_data, validation_data, test_data = object_detector.DataLoader.from_csv('./images.csv')
+def load_dataset(split_dir: Path, cache_dir: Path) -> object_detector.Dataset:
+    validate_coco_split(split_dir)
+    return object_detector.Dataset.from_coco_folder(str(split_dir), cache_dir=str(cache_dir))
 
-print("loaded data set...creating model")
 
-model = object_detector.create(train_data, model_spec=spec, epochs=100, batch_size=16, train_whole_model=True, validation_data=validation_data)
-print("created model.")
+def maybe_load_dataset(split_dir: Path | None, cache_dir: Path) -> object_detector.Dataset | None:
+    if split_dir is None or not split_dir.exists():
+        return None
+    return load_dataset(split_dir, cache_dir)
 
-# model.evaluate(test_data)
-print("exporting model")
 
-model.export(export_dir='.')
-print("evaluating model")
+def main() -> None:
+    args = parse_args()
 
-eval = model.evaluate_tflite('model.tflite', test_data)
+    train_dir = Path(args.train_data)
+    validation_dir = Path(args.validation_data)
+    test_dir = Path(args.test_data)
+    output_dir = Path(args.output_dir)
+    cache_dir = Path(args.cache_dir)
 
-print(eval)
+    output_dir.mkdir(parents=True, exist_ok=True)
+    cache_dir.mkdir(parents=True, exist_ok=True)
 
-print("finished")
+    train_data = load_dataset(train_dir, cache_dir)
+    validation_data = load_dataset(validation_dir, cache_dir)
+    test_data = maybe_load_dataset(test_dir, cache_dir)
+
+    options = object_detector.ObjectDetectorOptions(
+        supported_model=SUPPORTED_MODELS[args.model],
+        hparams=object_detector.HParams(
+            learning_rate=args.learning_rate,
+            batch_size=args.batch_size,
+            epochs=args.epochs,
+            cosine_decay_epochs=args.cosine_decay_epochs,
+            cosine_decay_alpha=args.cosine_decay_alpha,
+            export_dir=str(output_dir),
+        ),
+        model_options=object_detector.ModelOptions(
+            l2_weight_decay=args.l2_weight_decay,
+        ),
+    )
+
+    print("Loading dataset completed. Starting training...")
+    model = object_detector.ObjectDetector.create(
+        train_data=train_data,
+        validation_data=validation_data,
+        options=options,
+    )
+
+    validation_loss, validation_metrics = model.evaluate(validation_data, batch_size=args.batch_size)
+    print(f"Validation loss: {validation_loss}")
+    print(f"Validation metrics: {validation_metrics}")
+
+    if test_data is not None:
+        test_loss, test_metrics = model.evaluate(test_data, batch_size=args.batch_size)
+        print(f"Test loss: {test_loss}")
+        print(f"Test metrics: {test_metrics}")
+
+    model.export_model(model_name="model.tflite")
+    print(f"Exported float model to {output_dir / 'model.tflite'}")
+
+    if args.export_fp16:
+        fp16_config = quantization.QuantizationConfig.for_float16()
+        model.export_model(
+            model_name="model_fp16.tflite",
+            quantization_config=fp16_config,
+        )
+        print(f"Exported float16 model to {output_dir / 'model_fp16.tflite'}")
+
+    if args.run_qat:
+        qat_hparams = object_detector.QATHParams(
+            learning_rate=args.qat_learning_rate,
+            batch_size=args.qat_batch_size,
+            epochs=args.qat_epochs,
+            decay_steps=args.qat_decay_steps,
+            decay_rate=args.qat_decay_rate,
+        )
+        model.quantization_aware_training(
+            train_data=train_data,
+            validation_data=validation_data,
+            qat_hparams=qat_hparams,
+        )
+        qat_loss, qat_metrics = model.evaluate(validation_data, batch_size=args.qat_batch_size)
+        print(f"QAT validation loss: {qat_loss}")
+        print(f"QAT validation metrics: {qat_metrics}")
+        model.export_model(model_name="model_int8_qat.tflite")
+        print(f"Exported int8 QAT model to {output_dir / 'model_int8_qat.tflite'}")
+
+
+if __name__ == "__main__":
+    main()

--- a/train.py
+++ b/train.py
@@ -5,8 +5,14 @@ from pathlib import Path
 from mediapipe_model_maker import object_detector
 from mediapipe_model_maker import quantization
 
+from label_modes import (
+    DEFAULT_LABEL_MODE,
+    LABEL_MODE_CHOICES,
+    expected_classes,
+    label_mode_display_name,
+    label_mode_file_suffix,
+)
 
-EXPECTED_CLASSES = ["puck", "robot-front", "robot-back"]
 SUPPORTED_MODELS = {
     "mobilenet_v2": object_detector.SupportedModels.MOBILENET_V2,
     "mobilenet_v2_i320": object_detector.SupportedModels.MOBILENET_V2_I320,
@@ -57,6 +63,12 @@ def parse_args() -> argparse.Namespace:
     parser.add_argument("--cosine-decay-alpha", type=float, default=1.0)
     parser.add_argument("--l2-weight-decay", type=float, default=3e-5)
     parser.add_argument(
+        "--label-mode",
+        choices=LABEL_MODE_CHOICES,
+        default=DEFAULT_LABEL_MODE,
+        help="Expected dataset label mode. 'robot-merged' expects categories ['puck', 'robot'].",
+    )
+    parser.add_argument(
         "--export-fp16",
         action="store_true",
         help="Also export a float16 quantized TFLite model for GPU-oriented use.",
@@ -81,7 +93,20 @@ def load_categories(labels_path: Path) -> list[str]:
     return [category["name"] for category in sorted(categories, key=lambda item: item["id"])]
 
 
-def validate_coco_split(split_dir: Path) -> None:
+def load_dataset(split_dir: Path, cache_dir: Path, label_mode: str) -> object_detector.Dataset:
+    validate_coco_split(split_dir, label_mode)
+    return object_detector.Dataset.from_coco_folder(str(split_dir), cache_dir=str(cache_dir))
+
+
+def maybe_load_dataset(
+    split_dir: Path | None, cache_dir: Path, label_mode: str
+) -> object_detector.Dataset | None:
+    if split_dir is None or not split_dir.exists():
+        return None
+    return load_dataset(split_dir, cache_dir, label_mode)
+
+
+def validate_coco_split(split_dir: Path, label_mode: str) -> None:
     if not split_dir.exists():
         raise FileNotFoundError(f"COCO split not found: {split_dir}")
 
@@ -93,21 +118,38 @@ def validate_coco_split(split_dir: Path) -> None:
         raise FileNotFoundError(f"Missing images directory in {split_dir}")
 
     categories = load_categories(labels_path)
-    if categories != EXPECTED_CLASSES:
+    expected_category_names = expected_classes(label_mode)
+    if categories != expected_category_names:
         raise ValueError(
-            f"{labels_path} categories {categories} do not match expected {EXPECTED_CLASSES}"
+            f"{labels_path} categories {categories} do not match expected {expected_category_names}"
         )
 
 
-def load_dataset(split_dir: Path, cache_dir: Path) -> object_detector.Dataset:
-    validate_coco_split(split_dir)
-    return object_detector.Dataset.from_coco_folder(str(split_dir), cache_dir=str(cache_dir))
-
-
-def maybe_load_dataset(split_dir: Path | None, cache_dir: Path) -> object_detector.Dataset | None:
-    if split_dir is None or not split_dir.exists():
-        return None
-    return load_dataset(split_dir, cache_dir)
+def write_training_summary(
+    output_dir: Path,
+    args: argparse.Namespace,
+    validation_loss: list[float] | tuple[float, ...],
+    validation_metrics: dict,
+    test_loss: list[float] | tuple[float, ...] | None,
+    test_metrics: dict | None,
+) -> None:
+    summary = {
+        "label_mode": args.label_mode,
+        "label_mode_display_name": label_mode_display_name(args.label_mode),
+        "label_mode_file_suffix": label_mode_file_suffix(args.label_mode),
+        "classes": expected_classes(args.label_mode),
+        "model": args.model,
+        "epochs": args.epochs,
+        "batch_size": args.batch_size,
+        "learning_rate": args.learning_rate,
+        "validation_loss": list(validation_loss),
+        "validation_metrics": validation_metrics,
+        "test_loss": list(test_loss) if test_loss is not None else None,
+        "test_metrics": test_metrics,
+    }
+    with (output_dir / "training_summary.json").open("w", encoding="utf-8") as handle:
+        json.dump(summary, handle, indent=2)
+        handle.write("\n")
 
 
 def main() -> None:
@@ -122,9 +164,9 @@ def main() -> None:
     output_dir.mkdir(parents=True, exist_ok=True)
     cache_dir.mkdir(parents=True, exist_ok=True)
 
-    train_data = load_dataset(train_dir, cache_dir)
-    validation_data = load_dataset(validation_dir, cache_dir)
-    test_data = maybe_load_dataset(test_dir, cache_dir)
+    train_data = load_dataset(train_dir, cache_dir, args.label_mode)
+    validation_data = load_dataset(validation_dir, cache_dir, args.label_mode)
+    test_data = maybe_load_dataset(test_dir, cache_dir, args.label_mode)
 
     options = object_detector.ObjectDetectorOptions(
         supported_model=SUPPORTED_MODELS[args.model],
@@ -156,6 +198,19 @@ def main() -> None:
         test_loss, test_metrics = model.evaluate(test_data, batch_size=args.batch_size)
         print(f"Test loss: {test_loss}")
         print(f"Test metrics: {test_metrics}")
+    else:
+        test_loss = None
+        test_metrics = None
+
+    write_training_summary(
+        output_dir=output_dir,
+        args=args,
+        validation_loss=validation_loss,
+        validation_metrics=validation_metrics,
+        test_loss=test_loss,
+        test_metrics=test_metrics,
+    )
+    print(f"Wrote training summary to {output_dir / 'training_summary.json'}")
 
     model.export_model(model_name="model.tflite")
     print(f"Exported float model to {output_dir / 'model.tflite'}")

--- a/validate_coco.py
+++ b/validate_coco.py
@@ -1,0 +1,84 @@
+import argparse
+import json
+from collections import Counter
+from pathlib import Path
+
+
+EXPECTED_CLASSES = ["puck", "robot-front", "robot-back"]
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description="Validate a COCO dataset export for the smartphone robot detector.",
+    )
+    parser.add_argument(
+        "dataset_root",
+        help="Path to a COCO dataset directory containing images/ and labels.json.",
+    )
+    return parser.parse_args()
+
+
+def main() -> None:
+    args = parse_args()
+    dataset_root = Path(args.dataset_root)
+    labels_path = dataset_root / "labels.json"
+    images_dir = dataset_root / "images"
+
+    if not labels_path.is_file():
+        raise FileNotFoundError(f"Missing labels.json in {dataset_root}")
+    if not images_dir.is_dir():
+        raise FileNotFoundError(f"Missing images directory in {dataset_root}")
+
+    with labels_path.open("r", encoding="utf-8") as handle:
+        payload = json.load(handle)
+
+    categories = payload.get("categories", [])
+    images = payload.get("images", [])
+    annotations = payload.get("annotations", [])
+
+    category_names = [category["name"] for category in sorted(categories, key=lambda item: item["id"])]
+    if category_names != EXPECTED_CLASSES:
+        raise ValueError(
+            f"Category names {category_names} do not match expected {EXPECTED_CLASSES}"
+        )
+
+    image_ids = {image["id"] for image in images}
+    category_ids = {category["id"] for category in categories}
+    missing_files = []
+    annotation_count_by_class = Counter()
+
+    for image in images:
+        image_path = images_dir / image["file_name"]
+        if not image_path.is_file():
+            missing_files.append(str(image_path))
+
+    if missing_files:
+        raise FileNotFoundError(
+            f"Dataset references {len(missing_files)} missing image files. First missing file: {missing_files[0]}"
+        )
+
+    for annotation in annotations:
+        if annotation["image_id"] not in image_ids:
+            raise ValueError(f"Annotation references unknown image_id={annotation['image_id']}")
+        if annotation["category_id"] not in category_ids:
+            raise ValueError(f"Annotation references unknown category_id={annotation['category_id']}")
+        bbox = annotation.get("bbox")
+        if not bbox or len(bbox) != 4:
+            raise ValueError(f"Annotation {annotation.get('id')} has invalid bbox={bbox}")
+        _, _, width, height = bbox
+        if width <= 0 or height <= 0:
+            raise ValueError(f"Annotation {annotation.get('id')} has non-positive bbox={bbox}")
+        annotation_count_by_class[annotation["category_id"]] += 1
+
+    if not annotations:
+        raise ValueError("COCO dataset contains no annotations.")
+
+    print(f"Validated dataset: {dataset_root}")
+    print(f"Images: {len(images)}")
+    print(f"Annotations: {len(annotations)}")
+    for category in sorted(categories, key=lambda item: item["id"]):
+        print(f"{category['name']}: {annotation_count_by_class.get(category['id'], 0)} annotations")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- migrate the training pipeline from the legacy tf-model-maker flow to MediaPipe Model Maker with COCO dataset preparation
- restore GPU-capable Docker training and add reusable GitHub release and DockerHub publishing scripts
- add optional `--label-mode robot-merged` support while keeping `2.0.0` documented as the current 3-class model release

## Included
- local COCO dataset preparation and packaging helpers
- reusable release inputs for `2.0.0` and shortened publish commands
- release asset naming normalized to `dataset.zip` with legacy compatibility

## Follow-up after merge
- create tag `2.0.0` from the merge commit on `master`
- publish the scripted GitHub release and DockerHub image from that merge commit