### PR TITLE
Add reusable merged-model training and export hardening

### DIFF
--- a/README.md
+++ b/README.md
@@ -122,10 +122,10 @@ That archive is the expected GitHub Release asset format for later reuse.
 legacy compatibility name when downloading older releases.
 
 # Training
-The default training command assumes the prepared dataset layout created by `prepare_dataset.py`:
+The primary reusable training entrypoint is:
 
 ```bash
-python train.py --export-fp16
+python scripts/train_model.py --label-mode three-class
 ```
 
 Important paths:
@@ -138,30 +138,33 @@ Important paths:
 The default model is `mobilenet_multi_avg_i384`, which is one of the currently supported
 MediaPipe object detector training architectures.
 
-Useful training flags:
+Reusable training commands:
 
 ```bash
-python train.py --epochs 40 --batch-size 4
-python train.py --export-fp16
-python train.py --run-qat
-python prepare_dataset.py --label-mode robot-merged
-python train.py --label-mode robot-merged --export-fp16
+python scripts/train_model.py --label-mode three-class
+python scripts/train_model.py --label-mode robot-merged
+python scripts/train_model.py --label-mode robot-merged -- --epochs 40 --batch-size 4
+python scripts/train_model.py --label-mode three-class --build
 ```
 
-`--export-fp16` exports `model_fp16.tflite` for GPU-oriented deployment.
-`--run-qat` adds quantization-aware training and exports `model_int8_qat.tflite` for CPU-oriented deployment.
-`--label-mode robot-merged` prepares and validates a 2-class variant that merges `robot-front` and
-`robot-back` into `robot`.
+What the wrapper does:
+
+1. Prepares the dataset split with the requested `--label-mode`
+2. Runs the matching named Docker Compose service
+3. Exports `model.tflite` and, by default, `model_fp16.tflite`
+
+You can still call [train.py](/media/HDD/included/code/smartphone-robot/object-detection/train.py)
+directly for lower-level control, including `--run-qat` and other training flags.
 
 # Docker
-Build the training container and run the default training command:
+Named Docker Compose services are available for the reusable training modes:
 
 ```bash
-docker compose up --build
+docker compose up --build mediapipe-model-maker-3class
+docker compose up --build mediapipe-model-maker-robot-merged
 ```
 
-The compose service now uses the MediaPipe training script directly. Prepare the dataset first so
-`data/prepared/` exists in the mounted workspace.
+For normal use, prefer the wrapper script above so dataset preparation and training stay aligned.
 
 # Release Publishing
 Versioned release assets are prepared under `build/release/<tag>/`. The release scripts rename the

--- a/README.md
+++ b/README.md
@@ -186,7 +186,7 @@ The scripts resolve release metadata in this order:
 
 1. `exported_model/training_summary.json` for metrics from fresh training runs
 2. `release_inputs/<tag>.json` for release-specific metadata and fallback metrics
-3. built-in defaults for the Docker image and title
+3. built-in defaults for the Docker image and version-only release title
 
 That keeps the common release flow short while still allowing older training runs to be published
 without editing the scripts.

--- a/README.md
+++ b/README.md
@@ -152,6 +152,7 @@ What the wrapper does:
 1. Prepares the dataset split with the requested `--label-mode`
 2. Runs the matching named Docker Compose service
 3. Exports `model.tflite` and, by default, `model_fp16.tflite`
+4. Writes `training_summary.json` after export; summary writing is best-effort so it cannot discard a finished model export
 
 You can still call [train.py](/media/HDD/included/code/smartphone-robot/object-detection/train.py)
 directly for lower-level control, including `--run-qat` and other training flags.

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,13 +1,24 @@
+x-training-service: &training-service
+  build:
+    context: .
+    dockerfile: Dockerfile
+  image: mediapipe-model-maker
+  volumes:
+    - .:/object-detection
+  gpus: all
+  environment:
+    - NVIDIA_VISIBLE_DEVICES=all
+    - NVIDIA_DRIVER_CAPABILITIES=compute,utility
+
 services:
   mediapipe-model-maker:
-    build:
-      context: .
-      dockerfile: Dockerfile
-    image: mediapipe-model-maker
-    volumes:
-      - .:/object-detection
-    gpus: all
-    environment:
-      - NVIDIA_VISIBLE_DEVICES=all
-      - NVIDIA_DRIVER_CAPABILITIES=compute,utility
+    <<: *training-service
     command: python train.py --export-fp16
+
+  mediapipe-model-maker-3class:
+    <<: *training-service
+    command: python train.py --label-mode three-class --export-fp16
+
+  mediapipe-model-maker-robot-merged:
+    <<: *training-service
+    command: python train.py --label-mode robot-merged --export-fp16

--- a/release_inputs/2.0.0.json
+++ b/release_inputs/2.0.0.json
@@ -1,5 +1,5 @@
 {
-  "title": "Smartphone Robot Detector 2.0.0",
+  "title": "2.0.0",
   "label_mode": "three-class",
   "docker_image": "topher217/smartphone-robot-object-detection",
   "metrics": {

--- a/release_inputs/example.json
+++ b/release_inputs/example.json
@@ -1,5 +1,5 @@
 {
-  "title": "Smartphone Robot Detector 2.1.0",
+  "title": "2.1.0",
   "label_mode": "three-class",
   "docker_image": "topher217/smartphone-robot-object-detection",
   "metrics": {

--- a/scripts/prepare_release_assets.py
+++ b/scripts/prepare_release_assets.py
@@ -155,7 +155,7 @@ def build_release_notes(
 ) -> str:
     classes = ", ".join(expected_classes(label_mode))
     lines = [
-        f"# Smartphone Robot Detector {tag}",
+        f"# {tag}",
         "",
         f"- Published model variant: `{label_mode_display_name(label_mode)}`",
         f"- Classes in this release: `{classes}`",
@@ -254,7 +254,7 @@ def main() -> None:
 
     manifest_payload = {
         "tag": args.tag,
-        "title": release_input.get("title") or f"Smartphone Robot Detector {args.tag}",
+        "title": release_input.get("title") or args.tag,
         "label_mode": label_mode,
         "label_mode_display_name": label_mode_display_name(label_mode),
         "classes": expected_classes(label_mode),

--- a/scripts/publish_github_release.py
+++ b/scripts/publish_github_release.py
@@ -17,7 +17,7 @@ def parse_args() -> argparse.Namespace:
         description="Create or update a GitHub release from prepared detector assets.",
     )
     parser.add_argument("--tag", required=True, help="Release tag, for example 2.0.0.")
-    parser.add_argument("--title", help="Release title. Defaults to 'Smartphone Robot Detector <tag>'.")
+    parser.add_argument("--title", help="Release title. Defaults to the tag, for example '2.0.0'.")
     parser.add_argument("--repo", default=DEFAULT_REPO, help="GitHub repository in owner/name form.")
     parser.add_argument("--target", default="HEAD", help="Target commitish used when creating a new release.")
     parser.add_argument("--release-dir", default=str(DEFAULT_RELEASE_DIR))
@@ -79,7 +79,7 @@ def main() -> None:
         raise ValueError(f"No release assets found in {release_dir}")
 
     metadata_path = release_dir / "release-metadata.json"
-    release_title = f"Smartphone Robot Detector {args.tag}"
+    release_title = args.tag
     if metadata_path.is_file():
         import json
 

--- a/scripts/train_model.py
+++ b/scripts/train_model.py
@@ -1,0 +1,75 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import argparse
+import subprocess
+import sys
+from pathlib import Path
+
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description="Prepare the dataset and train a named detector variant.",
+    )
+    parser.add_argument(
+        "--label-mode",
+        choices=["three-class", "robot-merged"],
+        default="three-class",
+        help="Training variant to prepare and train.",
+    )
+    parser.add_argument(
+        "--no-fp16",
+        action="store_true",
+        help="Skip float16 export and only export the default floating-point model.",
+    )
+    parser.add_argument(
+        "--build",
+        action="store_true",
+        help="Rebuild the Docker image before training.",
+    )
+    parser.add_argument(
+        "train_args",
+        nargs=argparse.REMAINDER,
+        help="Additional arguments forwarded to train.py. Prefix them with --, for example -- --epochs 40",
+    )
+    return parser.parse_args()
+
+
+def main() -> None:
+    args = parse_args()
+    train_args = list(args.train_args)
+    if train_args and train_args[0] == "--":
+        train_args = train_args[1:]
+
+    subprocess.run(
+        [
+            sys.executable,
+            str(REPO_ROOT / "prepare_dataset.py"),
+            "--label-mode",
+            args.label_mode,
+        ],
+        cwd=REPO_ROOT,
+        check=True,
+    )
+
+    service_name = (
+        "mediapipe-model-maker-3class"
+        if args.label_mode == "three-class"
+        else "mediapipe-model-maker-robot-merged"
+    )
+    command = ["docker", "compose", "run"]
+    if args.build:
+        command.append("--build")
+    command.extend([service_name, "python", "train.py", "--label-mode", args.label_mode])
+    if not args.no_fp16:
+        command.append("--export-fp16")
+    command.extend(train_args)
+
+    subprocess.run(command, cwd=REPO_ROOT, check=True)
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/test_training_artifacts.py
+++ b/tests/test_training_artifacts.py
@@ -1,0 +1,53 @@
+import json
+import tempfile
+import unittest
+from pathlib import Path
+
+from training_artifacts import to_jsonable, training_summary_payload, write_json_atomically
+
+
+class FakeScalar:
+    def __init__(self, value):
+        self._value = value
+
+    def item(self):
+        return self._value
+
+
+class TrainingArtifactsTest(unittest.TestCase):
+    def test_to_jsonable_converts_nested_scalar_like_values(self):
+        payload = {
+            "metrics": {
+                "AP": FakeScalar(0.5),
+                "nested": [FakeScalar(1.25)],
+            }
+        }
+        converted = to_jsonable(payload)
+        self.assertEqual(converted, {"metrics": {"AP": 0.5, "nested": [1.25]}})
+
+    def test_write_json_atomically_writes_valid_json(self):
+        with tempfile.TemporaryDirectory() as temp_dir:
+            output_path = Path(temp_dir) / "training_summary.json"
+            summary = training_summary_payload(
+                label_mode="robot-merged",
+                model="mobilenet_multi_avg_i384",
+                epochs=30,
+                batch_size=8,
+                learning_rate=0.3,
+                validation_loss=[FakeScalar(0.1), FakeScalar(0.2)],
+                validation_metrics={"AP": FakeScalar(0.55), "AP50": FakeScalar(0.82)},
+                test_loss=[FakeScalar(0.3)],
+                test_metrics={"AP": FakeScalar(0.45)},
+            )
+
+            write_json_atomically(output_path, summary)
+
+            loaded = json.loads(output_path.read_text(encoding="utf-8"))
+            self.assertEqual(loaded["label_mode"], "robot-merged")
+            self.assertEqual(loaded["classes"], ["puck", "robot"])
+            self.assertEqual(loaded["validation_metrics"]["AP"], 0.55)
+            self.assertFalse((Path(temp_dir) / "training_summary.json.tmp").exists())
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/train.py
+++ b/train.py
@@ -9,9 +9,8 @@ from label_modes import (
     DEFAULT_LABEL_MODE,
     LABEL_MODE_CHOICES,
     expected_classes,
-    label_mode_display_name,
-    label_mode_file_suffix,
 )
+from training_artifacts import training_summary_payload, write_json_atomically
 
 SUPPORTED_MODELS = {
     "mobilenet_v2": object_detector.SupportedModels.MOBILENET_V2,
@@ -133,23 +132,18 @@ def write_training_summary(
     test_loss: list[float] | tuple[float, ...] | None,
     test_metrics: dict | None,
 ) -> None:
-    summary = {
-        "label_mode": args.label_mode,
-        "label_mode_display_name": label_mode_display_name(args.label_mode),
-        "label_mode_file_suffix": label_mode_file_suffix(args.label_mode),
-        "classes": expected_classes(args.label_mode),
-        "model": args.model,
-        "epochs": args.epochs,
-        "batch_size": args.batch_size,
-        "learning_rate": args.learning_rate,
-        "validation_loss": list(validation_loss),
-        "validation_metrics": validation_metrics,
-        "test_loss": list(test_loss) if test_loss is not None else None,
-        "test_metrics": test_metrics,
-    }
-    with (output_dir / "training_summary.json").open("w", encoding="utf-8") as handle:
-        json.dump(summary, handle, indent=2)
-        handle.write("\n")
+    summary = training_summary_payload(
+        label_mode=args.label_mode,
+        model=args.model,
+        epochs=args.epochs,
+        batch_size=args.batch_size,
+        learning_rate=args.learning_rate,
+        validation_loss=validation_loss,
+        validation_metrics=validation_metrics,
+        test_loss=test_loss,
+        test_metrics=test_metrics,
+    )
+    write_json_atomically(output_dir / "training_summary.json", summary)
 
 
 def main() -> None:
@@ -202,16 +196,6 @@ def main() -> None:
         test_loss = None
         test_metrics = None
 
-    write_training_summary(
-        output_dir=output_dir,
-        args=args,
-        validation_loss=validation_loss,
-        validation_metrics=validation_metrics,
-        test_loss=test_loss,
-        test_metrics=test_metrics,
-    )
-    print(f"Wrote training summary to {output_dir / 'training_summary.json'}")
-
     model.export_model(model_name="model.tflite")
     print(f"Exported float model to {output_dir / 'model.tflite'}")
 
@@ -222,6 +206,19 @@ def main() -> None:
             quantization_config=fp16_config,
         )
         print(f"Exported float16 model to {output_dir / 'model_fp16.tflite'}")
+
+    try:
+        write_training_summary(
+            output_dir=output_dir,
+            args=args,
+            validation_loss=validation_loss,
+            validation_metrics=validation_metrics,
+            test_loss=test_loss,
+            test_metrics=test_metrics,
+        )
+        print(f"Wrote training summary to {output_dir / 'training_summary.json'}")
+    except Exception as exc:
+        print(f"Warning: failed to write training summary: {exc}")
 
     if args.run_qat:
         qat_hparams = object_detector.QATHParams(

--- a/training_artifacts.py
+++ b/training_artifacts.py
@@ -1,0 +1,55 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from label_modes import expected_classes, label_mode_display_name, label_mode_file_suffix
+
+
+def to_jsonable(value):
+    if isinstance(value, dict):
+        return {key: to_jsonable(item) for key, item in value.items()}
+    if isinstance(value, (list, tuple)):
+        return [to_jsonable(item) for item in value]
+    if hasattr(value, "item"):
+        try:
+            return value.item()
+        except (TypeError, ValueError):
+            pass
+    return value
+
+
+def training_summary_payload(
+    *,
+    label_mode: str,
+    model: str,
+    epochs: int,
+    batch_size: int,
+    learning_rate: float,
+    validation_loss,
+    validation_metrics,
+    test_loss,
+    test_metrics,
+) -> dict:
+    return {
+        "label_mode": label_mode,
+        "label_mode_display_name": label_mode_display_name(label_mode),
+        "label_mode_file_suffix": label_mode_file_suffix(label_mode),
+        "classes": expected_classes(label_mode),
+        "model": model,
+        "epochs": epochs,
+        "batch_size": batch_size,
+        "learning_rate": learning_rate,
+        "validation_loss": list(validation_loss),
+        "validation_metrics": validation_metrics,
+        "test_loss": list(test_loss) if test_loss is not None else None,
+        "test_metrics": test_metrics,
+    }
+
+
+def write_json_atomically(path: Path, payload: dict) -> None:
+    temp_path = path.with_name(f"{path.name}.tmp")
+    with temp_path.open("w", encoding="utf-8") as handle:
+        json.dump(to_jsonable(payload), handle, indent=2)
+        handle.write("\n")
+    temp_path.replace(path)


### PR DESCRIPTION
## Summary
- add reusable named training entrypoints for the three-class and robot-merged variants
- keep GitHub release titles version-only
- harden long training runs by exporting model artifacts before optional summary writing

## Why
- the merged-model release should be built from a merge commit on `master`
- training the model is GPU-expensive, so post-training metadata failures should not discard a completed export
- the repo now has a stable reusable command for `robot-merged` training instead of an ad hoc compose invocation